### PR TITLE
fix: restrict focus sessions to one active at a time (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ mindloop.log
 # Server process management
 .mindloop-server.pid
 server.log
+
+.gemini/
+gha-creds-*.json

--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -264,10 +264,19 @@ func (mlh *MindloopHandler) HandleFocus(w http.ResponseWriter, r *http.Request) 
 		sessions[i], sessions[j] = sessions[j], sessions[i]
 	}
 
-	mlh.renderTemplate(w, "focus.html", map[string]interface{}{
+	data := map[string]interface{}{
 		"Title":    "Focus",
 		"Sessions": sessions,
-	})
+	}
+
+	if success := r.URL.Query().Get("success"); success == "true" {
+		data["SuccessMessage"] = "Action completed successfully"
+	}
+	if errStr := r.URL.Query().Get("error"); errStr != "" {
+		data["ErrorMessage"] = errStr
+	}
+
+	mlh.renderTemplate(w, "focus.html", data)
 }
 
 func (mlh *MindloopHandler) HandleFocusStart(w http.ResponseWriter, r *http.Request) {
@@ -279,8 +288,10 @@ func (mlh *MindloopHandler) HandleFocusStart(w http.ResponseWriter, r *http.Requ
 	_, err := mlh.focus.StartSession(title)
 	if err != nil {
 		log.Error().Err(err).Msg("Error starting focus session")
+		http.Redirect(w, r, "/focus?error="+err.Error(), http.StatusSeeOther)
+		return
 	}
-	http.Redirect(w, r, "/focus", http.StatusSeeOther)
+	http.Redirect(w, r, "/focus?success=true", http.StatusSeeOther)
 }
 
 func (mlh *MindloopHandler) HandleFocusStop(w http.ResponseWriter, r *http.Request) {
@@ -293,8 +304,10 @@ func (mlh *MindloopHandler) HandleFocusStop(w http.ResponseWriter, r *http.Reque
 	_, err := mlh.focus.EndSession(id)
 	if err != nil {
 		log.Error().Err(err).Msg("Error ending focus session")
+		http.Redirect(w, r, "/focus?error="+err.Error(), http.StatusSeeOther)
+		return
 	}
-	http.Redirect(w, r, "/focus", http.StatusSeeOther)
+	http.Redirect(w, r, "/focus?success=true", http.StatusSeeOther)
 }
 
 func (mlh *MindloopHandler) HandleFocusDelete(w http.ResponseWriter, r *http.Request) {
@@ -306,8 +319,10 @@ func (mlh *MindloopHandler) HandleFocusDelete(w http.ResponseWriter, r *http.Req
 	id, _ := strconv.Atoi(idStr)
 	if err := mlh.focus.DeleteSession(id); err != nil {
 		log.Error().Err(err).Msg("Error deleting focus session")
+		http.Redirect(w, r, "/focus?error="+err.Error(), http.StatusSeeOther)
+		return
 	}
-	http.Redirect(w, r, "/focus", http.StatusSeeOther)
+	http.Redirect(w, r, "/focus?success=true", http.StatusSeeOther)
 }
 
 // --- Summary Handler ---

--- a/api/v1/handlers_test.go
+++ b/api/v1/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	v1 "github.com/snehmatic/mindloop/api/v1"
+	"github.com/snehmatic/mindloop/internal/config"
 	"github.com/snehmatic/mindloop/internal/core/focus"
 	"github.com/snehmatic/mindloop/internal/core/habit"
 	"github.com/snehmatic/mindloop/internal/core/intent"
@@ -20,6 +21,9 @@ import (
 )
 
 func setupTestServer(t *testing.T) *v1.MindloopHandler {
+	// Initialize global config for tests
+	config.InitConfig("MindloopTest", "local", ":8765")
+
 	// Use in-memory DB for testing
 	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
@@ -151,7 +155,7 @@ func TestSummaryGeneration(t *testing.T) {
 		t.Errorf("Summary failed with status %d", w.Code)
 	}
 
-	if !strings.Contains(w.Body.String(), "Weekly Summary") {
+	if !strings.Contains(w.Body.String(), "Summary Report") {
 		t.Errorf("Summary page content missing expected title")
 	}
 }

--- a/internal/core/focus/focus.go
+++ b/internal/core/focus/focus.go
@@ -21,6 +21,11 @@ func (s *Service) StartSession(title string) (*models.FocusSession, error) {
 		return nil, errors.New("title cannot be empty")
 	}
 
+	var activeSession models.FocusSession
+	if err := s.DB.Where("status = ?", "active").First(&activeSession).Error; err == nil {
+		return nil, errors.New("a focus session is already active")
+	}
+
 	session := &models.FocusSession{
 		Title:  title,
 		Status: "active",

--- a/internal/core/focus/focus_test.go
+++ b/internal/core/focus/focus_test.go
@@ -1,0 +1,95 @@
+package focus_test
+
+import (
+	"testing"
+
+	"github.com/snehmatic/mindloop/internal/core/focus"
+	"github.com/snehmatic/mindloop/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		NamingStrategy: schema.NamingStrategy{
+			SingularTable: true,
+			NoLowerCase:   true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to connect to test db: %v", err)
+	}
+
+	err = db.AutoMigrate(&models.FocusSession{})
+	if err != nil {
+		t.Fatalf("Failed to migrate test db: %v", err)
+	}
+
+	return db
+}
+
+func TestStartSession(t *testing.T) {
+	db := setupTestDB(t)
+	s := focus.NewService(db)
+
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "start first session",
+			title:   "Session 1",
+			wantErr: false,
+		},
+		{
+			name:    "start second session while first is active",
+			title:   "Session 2",
+			wantErr: true,
+			errMsg:  "a focus session is already active",
+		},
+		{
+			name:    "start session with empty title",
+			title:   "",
+			wantErr: true,
+			errMsg:  "title cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := s.StartSession(tt.title)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("StartSession() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && err.Error() != tt.errMsg {
+				t.Errorf("StartSession() error message = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestEndAndRestartSession(t *testing.T) {
+	db := setupTestDB(t)
+	s := focus.NewService(db)
+
+	// 1. Start session
+	sess, err := s.StartSession("Session 1")
+	if err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+
+	// 2. End session
+	_, err = s.EndSession(int(sess.ID))
+	if err != nil {
+		t.Fatalf("Failed to end session: %v", err)
+	}
+
+	// 3. Start another session - should succeed
+	_, err = s.StartSession("Session 2")
+	if err != nil {
+		t.Errorf("Failed to start second session after ending first: %v", err)
+	}
+}


### PR DESCRIPTION
## Overview
This PR addresses Issue #2 by restricting focus sessions to only one active session at a time. 

## Changes
- **Core Logic:** Updated `internal/core/focus/focus.go` to check for any existing session with `status = "active"` before starting a new one.
- **Testing:** Added `internal/core/focus/focus_test.go` with table-driven tests to verify:
    - Starting the first session succeeds.
    - Starting a second session while one is active fails with an error.
    - Starting a session with an empty title fails.
    - Ending a session and then starting a new one succeeds.
- **Web UI:** Updated `api/v1/handlers_impl.go` to:
    - Pass success/error messages via query parameters to the focus page.
    - Properly redirect with error messages when session operations (start, stop, delete) fail.
- **Test Fixes:** 
    - Updated `api/v1/handlers_test.go` to initialize global configuration, preventing nil pointer dereferences in template functions (like `asset`).
    - Updated `TestSummaryGeneration` to match the actual "Summary Report" title in the template.

## Verification
- Ran `go test ./internal/core/focus/...` -> PASS
- Ran `make test` -> PASS (all tests)
