### PR TITLE
Standardize storage location and add versioning support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X github.com/snehmatic/mindloop/internal/config.Version={{.Version}}
 
 archives:
   - formats: 
@@ -68,3 +68,9 @@ brews:
     
     install: |
       bin.install "mindloop"
+
+    service: |
+      run [opt_bin/"mindloop", "server"]
+      keep_alive true
+      log_path var/"log/mindloop.log"
+      error_log_path var/"log/mindloop.log"

--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ Mindloop follows a clean architecture pattern, separating core business logic fr
     *   `summary`: Aggregates data for productivity reporting.
 
 *   **Interfaces (Presentation Layer):**
-    *   **CLI (`cmd/cli`):** Built with [Cobra](https://github.com/spf13/cobra), this interface interacts directly with the local database for low-latency command-line usage. Check out the [CLI Usage Guide](docs/CLI_USAGE.md) for detailed command instructions.
+    *   **CLI (`cmd/cli`):** Built with [Cobra](https://github.com/spf13/cobra), this interface interacts directly with the local database for low-latency command-line usage. Use `mindloop --version` to check your current version. Check out the [CLI Usage Guide](docs/CLI_USAGE.md) for detailed command instructions.
     *   **Web Server (`cmd/server`):** A Go HTTP server exposing a REST API (`api/v1`).
     *   **Web UI:** Server-Side Rendered (SSR) HTML templates (`web/templates`) utilizing vanilla CSS/JS. "Vibe coded" with Gemini (backend-focused developer approach).
 
 *   **Data Layer:**
     *   Uses [GORM](https://gorm.io/) for ORM capabilities.
-    *   **Default:** Zero-config SQLite (`mindloop_local.db`) for a true local-first experience.
+    *   **Default:** Zero-config SQLite (`mindloop_local.db`).
+    *   **Universal Storage:** By default, data is stored in `~/.mindloop/` to ensure persistence across different working directories. It also checks for a local `mindloop_local.db` in the current directory for project-specific overrides.
     *   **Optional:** Supports PostgreSQL via configuration (BYODB mode).
 
 ---
@@ -80,6 +81,12 @@ The easiest way to install and keep Mindloop updated.
 ```bash
 brew tap snehmatic/mindloop
 brew install mindloop
+```
+
+**Run as a background service:**
+You can use Homebrew Services to run the Mindloop server in the background:
+```bash
+brew services start mindloop
 ```
 
 #### Option 2: Go Install

--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -737,7 +737,8 @@ func (mlh *MindloopHandler) HandleNoteDelete(w http.ResponseWriter, r *http.Requ
 }
 func (mlh *MindloopHandler) HandleAbout(w http.ResponseWriter, r *http.Request) {
 	mlh.renderTemplate(w, "about.html", map[string]interface{}{
-		"Title": "About",
+		"Title":   "About",
+		"Version": config.Version,
 	})
 }
 

--- a/cmd/cli/configure.go
+++ b/cmd/cli/configure.go
@@ -86,5 +86,5 @@ func CreateUserConfigYAML(username, mode string, dbConfig *config.DBConfig) {
 
 	uc.WriteToYAML()
 	PrintSuccessln("User config created successfully!")
-	PrintInfoln("You can find your config as user_config.yaml")
+	PrintInfof("You can find your config at: %s\n", config.GetUserConfigPath())
 }

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -17,6 +17,7 @@ var ac *config.Config
 
 var rootCmd = &cobra.Command{
 	Use:       "mindloop",
+	Version:   config.Version,
 	Short:     "mindloop is a CLI tool for productivity tracking",
 	Long:      `Mindloop helps track intent, focus sessions, and habits via CLI.`,
 	Example:   `mindloop intent start "Get this work done"`,

--- a/db/db.go
+++ b/db/db.go
@@ -35,8 +35,17 @@ func Conn(connString string) (*gorm.DB, error) {
 	return db, nil
 }
 
+func GetLocalDBPath() string {
+	localFile := "mindloop_local.db"
+	if utils.FileExists(localFile) {
+		return localFile
+	}
+	return config.GetDataDir() + "/" + localFile
+}
+
 func LocalConn() (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open("mindloop_local.db"), &gorm.Config{
+	dbPath := GetLocalDBPath()
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
 			SingularTable: true,
 			NoLowerCase:   true,
@@ -51,7 +60,7 @@ func LocalConn() (*gorm.DB, error) {
 		return db, err
 	}
 
-	logger.Info().Msg("Connected to local SQLite DB, migrations complete!")
+	logger.Info().Msgf("Connected to local SQLite DB at %s, migrations complete!", dbPath)
 	return db, nil
 }
 
@@ -77,7 +86,7 @@ func ConnectToDb(appConfig config.Config) (*gorm.DB, error) {
 }
 
 func LocalDBFileExists() bool {
-	return utils.FileExists("mindloop_local.db")
+	return utils.FileExists(GetLocalDBPath())
 }
 
 func MigrateDB(db *gorm.DB) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,9 +13,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// UserConfigPath is the file path where the user configuration YAML will be written.
-// ToDo: Make this configurable or use a constant
-var UserConfigPath = "user_config.yaml"
+func GetUserConfigPath() string {
+	localFile := "user_config.yaml"
+	if _, err := os.Stat(localFile); err == nil {
+		return localFile
+	}
+	return GetDataDir() + "/" + localFile
+}
+
+// Version is set during build time via ldflags
+var Version = "dev"
+
+func GetDataDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	dir := homeDir + "/.mindloop"
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		_ = os.MkdirAll(dir, 0755)
+	}
+	return dir
+}
 
 type MindloopMode string
 
@@ -99,8 +118,9 @@ type FeatureFlags struct {
 func ValidateUserConfig(cmd *cobra.Command) {
 	// check if user_config.yaml exists
 	logger := log.Get()
-	if utils.FileExists(UserConfigPath) {
-		logger.Debug().Msgf("User config exists at %s", UserConfigPath)
+	configPath := GetUserConfigPath()
+	if utils.FileExists(configPath) {
+		logger.Debug().Msgf("User config exists at %s", configPath)
 	} else {
 		if cmd.Use != "configure" {
 			utils.PrintWarnln("Warn: user config does not exist, create a new one or run `mindloop configure`.")
@@ -116,7 +136,7 @@ func (uc UserConfig) WriteToYAML() {
 		utils.PrintErrorln("Error marshalling user config to YAML")
 		return
 	}
-	err = os.WriteFile(UserConfigPath, marshalled, 0644)
+	err = os.WriteFile(GetUserConfigPath(), marshalled, 0644)
 	if err != nil {
 		utils.PrintErrorln("Error writing user config to file")
 		return
@@ -125,7 +145,7 @@ func (uc UserConfig) WriteToYAML() {
 }
 
 func (uc *UserConfig) ReadFromYAML() error {
-	data, err := os.ReadFile(UserConfigPath)
+	data, err := os.ReadFile(GetUserConfigPath())
 	if err != nil {
 		return fmt.Errorf("failed to read user config file: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -14,14 +14,18 @@ const (
 )
 
 func main() {
-	logFile, err := os.OpenFile("mindloop.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	logPath := "mindloop.log"
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		logPath = config.GetDataDir() + "/mindloop.log"
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		panic("Failed to open log file: " + err.Error())
 	}
 	defer logFile.Close()
 	log.Init(logFile, zerolog.DebugLevel)
 	logger := log.Get()
-	logger.Info().Msg("Logging to mindloop.log file...")
+	logger.Info().Msgf("Logging to %s file...", logPath)
 
 	// Init global config
 	config.InitConfig(AppName, "local", "")

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -24,7 +24,7 @@
         <img src="/static/images/about-zen.png" alt="Zen Balance"
             style="max-width: 150px; margin-bottom: 1rem; border-radius: 50%; opacity: 0.8;">
         <p>Built with Go on the backend and pure HTML/CSS on the frontend.</p>
-        <p class="text-sm text-muted">Version 1.0.0 - Mindfulness Edition</p>
+        <p class="text-sm text-muted">Version {{ .Version }} - Mindfulness Edition</p>
     </div>
 </div>
 {{ end }}


### PR DESCRIPTION
This PR standardizes the storage location for Mindloop's data and configuration files, ensuring a consistent experience across different working directories. It also introduces proper versioning support for both the CLI and Web UI.

### Changes:
- **Storage:** Default database, configuration, and log files are now stored in `~/.mindloop/`.
- **Backward Compatibility:** Checks for local files in the current directory first.
- **CLI Versioning:** Added `--version` flag to the CLI.
- **UI Versioning:** Displays the dynamic version on the About page.
- **Homebrew:** Added Homebrew Service support to `.goreleaser.yaml` for background server management.

Fixes #50