### PR TITLE
feat: Sort lists by default (newest first)

### DIFF
--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -399,10 +399,6 @@ func (mlh *MindloopHandler) HandleIntentDelete(w http.ResponseWriter, r *http.Re
 
 func (mlh *MindloopHandler) HandleFocus(w http.ResponseWriter, r *http.Request) {
 	sessions, _ := mlh.focus.ListSessions()
-	// reverse order to show newest first
-	for i, j := 0, len(sessions)-1; i < j; i, j = i+1, j-1 {
-		sessions[i], sessions[j] = sessions[j], sessions[i]
-	}
 
 	data := map[string]interface{}{
 		"Title":    "Focus",

--- a/internal/core/focus/focus.go
+++ b/internal/core/focus/focus.go
@@ -42,7 +42,7 @@ func (s *Service) StartSession(title string) (*models.FocusSession, error) {
 
 func (s *Service) ListSessions() ([]models.FocusSession, error) {
 	var sessions []models.FocusSession
-	result := s.DB.Find(&sessions)
+	result := s.DB.Order("CreatedAt DESC").Find(&sessions)
 	return sessions, result.Error
 }
 

--- a/internal/core/habit/habit.go
+++ b/internal/core/habit/habit.go
@@ -68,14 +68,14 @@ func (s *Service) ListHabits(interval models.IntervalType) ([]models.Habit, erro
 	now := time.Now()
 	query = query.Where("EndDate IS NULL OR EndDate > ?", now)
 
-	result := query.Find(&habits)
+	result := query.Order("CreatedAt DESC").Find(&habits)
 	return habits, result.Error
 }
 
 func (s *Service) ListEndedHabits() ([]models.Habit, error) {
 	var habits []models.Habit
 	now := time.Now()
-	result := s.DB.Where("EndDate IS NOT NULL AND EndDate <= ?", now).Find(&habits)
+	result := s.DB.Where("EndDate IS NOT NULL AND EndDate <= ?", now).Order("CreatedAt DESC").Find(&habits)
 	return habits, result.Error
 }
 

--- a/internal/core/intent/intent.go
+++ b/internal/core/intent/intent.go
@@ -34,13 +34,13 @@ func (s *Service) StartIntent(name string) (*models.Intent, error) {
 
 func (s *Service) ListIntents() ([]models.Intent, error) {
 	var intents []models.Intent
-	result := s.DB.Find(&intents)
+	result := s.DB.Order("CreatedAt DESC").Find(&intents)
 	return intents, result.Error
 }
 
 func (s *Service) ListActiveIntents() ([]models.Intent, error) {
 	var intents []models.Intent
-	result := s.DB.Where("status = ?", "active").Find(&intents)
+	result := s.DB.Where("status = ?", "active").Order("CreatedAt DESC").Find(&intents)
 	return intents, result.Error
 }
 

--- a/internal/core/quest/quest.go
+++ b/internal/core/quest/quest.go
@@ -65,7 +65,7 @@ func (s *Service) StopQuest(id uint, note string) (*models.SideQuest, error) {
 
 func (s *Service) ListQuests() ([]models.SideQuest, error) {
 	var quests []models.SideQuest
-	result := s.DB.Find(&quests)
+	result := s.DB.Order("CreatedAt DESC").Find(&quests)
 	return quests, result.Error
 }
 

--- a/internal/core/summary/summary.go
+++ b/internal/core/summary/summary.go
@@ -73,7 +73,7 @@ func (s *Service) GetFocusStats(start, end time.Time) (models.FocusStats, error)
 
 func (s *Service) GetHabitStats(start, end time.Time) ([]models.HabitStats, error) {
 	var habits []models.Habit
-	if err := s.DB.Find(&habits).Error; err != nil {
+	if err := s.DB.Order("CreatedAt DESC").Find(&habits).Error; err != nil {
 		return nil, err
 	}
 	if len(habits) == 0 {
@@ -116,7 +116,7 @@ func (s *Service) GetHabitStats(start, end time.Time) ([]models.HabitStats, erro
 func (s *Service) GetIntentStats(start, end time.Time) ([]models.IntentStats, error) {
 	var intents []models.Intent
 	rangeQuery := "CreatedAt >= ? AND CreatedAt <= ?"
-	if err := s.DB.Where(rangeQuery, start, end).Find(&intents).Error; err != nil {
+	if err := s.DB.Where(rangeQuery, start, end).Order("CreatedAt DESC").Find(&intents).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description
This PR addresses Issue #51 by ensuring all lists (Habits, Focus Sessions, Intents, Quests) are sorted by creation date descending (newest first) by default in both the Core Service layer and the API/UI.

# Changes
- Updated `ListHabits`, `ListEndedHabits`, `ListSessions`, `ListIntents`, `ListActiveIntents`, `ListQuests` in `internal/core` to use `.Order("CreatedAt DESC")`.
- Updated `summary` service to use sorted queries for stats generation.
- Removed manual reversal in `HandleFocus` handler as it is no longer needed.
- Verified with unit tests (`make test`).

# Future Considerations
- A "Sort By" button could be added to the UI in the future for user customization (Low Priority).

Fixes #51