### PR TITLE
fix: address golangci-lint errors and add lint target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ test:
 	@echo "  >  Running tests..."
 	go test ./...
 
+## lint: Run linters
+lint:
+	@echo "  >  Running linters..."
+	golangci-lint run
+
 ## fmt: Format all go files
 fmt:
 	@echo "  >  Formatting code..."

--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -967,7 +967,11 @@ func (mlh *MindloopHandler) HandleBackupExport(w http.ResponseWriter, r *http.Re
 		http.Redirect(w, r, "/settings?error=Failed to create backup file", http.StatusSeeOther)
 		return
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			log.Error().Err(err).Msg("Error removing temp backup file")
+		}
+	}()
 
 	if err := mlh.backup.Export(tmpFile.Name()); err != nil {
 		log.Error().Err(err).Msg("Error exporting backup")
@@ -992,7 +996,11 @@ func (mlh *MindloopHandler) HandleBackupImport(w http.ResponseWriter, r *http.Re
 		http.Redirect(w, r, "/settings?error=No file uploaded", http.StatusSeeOther)
 		return
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Error().Err(err).Msg("Error closing uploaded file")
+		}
+	}()
 
 	tmpFile, err := os.CreateTemp("", "mindloop_import_*.json")
 	if err != nil {
@@ -1000,7 +1008,11 @@ func (mlh *MindloopHandler) HandleBackupImport(w http.ResponseWriter, r *http.Re
 		http.Redirect(w, r, "/settings?error=Import failed", http.StatusSeeOther)
 		return
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			log.Error().Err(err).Msg("Error removing temp import file")
+		}
+	}()
 
 	// Copy uploaded file to temp file
 	data, err := io.ReadAll(file)

--- a/cmd/cli/backup.go
+++ b/cmd/cli/backup.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/snehmatic/mindloop/internal/core/backup"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -22,12 +22,12 @@ var backupCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		filePath := args[0]
-		PrintRocketf("Exporting data to %s...\n", filePath)
+		utils.PrintRocketf("Exporting data to %s...\n", filePath)
 		if err := backupService.Export(filePath); err != nil {
-			PrintErrorln("Backup failed:", err)
+			utils.PrintErrorln("Backup failed:", err)
 			return
 		}
-		PrintSuccessln("Backup completed successfully!")
+		utils.PrintSuccessln("Backup completed successfully!")
 	},
 }
 
@@ -42,21 +42,21 @@ var restoreCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		filePath := args[0]
-		PrintWarnf("Restoring data from %s. All existing local data will be replaced!\n", filePath)
-		PrintInfoln("Type 'yes' to confirm:")
+		utils.PrintWarnf("Restoring data from %s. All existing local data will be replaced!\n", filePath)
+		utils.PrintInfoln("Type 'yes' to confirm:")
 		var confirm string
 		_, _ = fmt.Scanln(&confirm)
 		if confirm != "yes" {
-			PrintInfoln("Restore cancelled.")
+			utils.PrintInfoln("Restore cancelled.")
 			return
 		}
 
-		PrintRocketln("Importing data...")
+		utils.PrintRocketln("Importing data...")
 		if err := backupService.Import(filePath); err != nil {
-			PrintErrorln("Restore failed:", err)
+			utils.PrintErrorln("Restore failed:", err)
 			return
 		}
-		PrintSuccessln("Restore completed successfully!")
+		utils.PrintSuccessln("Restore completed successfully!")
 	},
 }
 

--- a/cmd/cli/configure.go
+++ b/cmd/cli/configure.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/snehmatic/mindloop/internal/config"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +17,7 @@ var confCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Placeholder for configuration logic
 		// This could involve setting user preferences, etc.
-		PrintRocketln("Welcome to Mindloop configuration!")
+		utils.PrintRocketln("Welcome to Mindloop configuration!")
 		fmt.Print("Please enter your preferred username: ")
 		var username string
 		_, _ = fmt.Scanln(&username)
@@ -28,7 +28,7 @@ var confCmd = &cobra.Command{
 			if models.IsValidMode(mode) {
 				break
 			}
-			PrintWarnln("Invalid mode. Please choose from: local, byodb.")
+			utils.PrintWarnln("Invalid mode. Please choose from: local, byodb.")
 		}
 
 		dbConfig := &config.DBConfig{}
@@ -62,7 +62,7 @@ var confCmd = &cobra.Command{
 
 		CreateUserConfigYAML(username, mode, dbConfig)
 
-		PrintSuccessf("Configuration complete! Your username is set to: %s, using mode: %s\n", username, mode)
+		utils.PrintSuccessf("Configuration complete! Your username is set to: %s, using mode: %s\n", username, mode)
 	},
 }
 
@@ -78,13 +78,13 @@ func CreateUserConfigYAML(username, mode string, dbConfig *config.DBConfig) {
 
 	if mode == "byodb" {
 		if dbConfig == nil {
-			PrintWarnln("Database configuration is required for 'byodb' mode. Please try again.")
+			utils.PrintWarnln("Database configuration is required for 'byodb' mode. Please try again.")
 			return
 		}
 		uc.DbConfig = *dbConfig
 	}
 
 	uc.WriteToYAML()
-	PrintSuccessln("User config created successfully!")
-	PrintInfof("You can find your config at: %s\n", config.GetUserConfigPath())
+	utils.PrintSuccessln("User config created successfully!")
+	utils.PrintInfof("You can find your config at: %s\n", config.GetUserConfigPath())
 }

--- a/cmd/cli/focus.go
+++ b/cmd/cli/focus.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 
 	"github.com/snehmatic/mindloop/internal/core/focus"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -31,14 +31,14 @@ var focusStartCmd = &cobra.Command{
 	Example: `mindloop focus start "Work on project"`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		PrintRocketln("That's the spirit! Starting a new focus session...")
+		utils.PrintRocketln("That's the spirit! Starting a new focus session...")
 		session, err := focusService.StartSession(args[0])
 		if err != nil {
-			PrintErrorln("Error starting focus session:", err)
+			utils.PrintErrorln("Error starting focus session:", err)
 			ac.Logger.Error().Msgf("Error starting focus session: %v", err)
 			return
 		}
-		PrintSuccessf("Focus session '%s' started successfully with id %d!\n", session.Title, session.ID)
+		utils.PrintSuccessf("Focus session '%s' started successfully with id %d!\n", session.Title, session.ID)
 		ac.Logger.Info().Msgf("Focus session '%s' started successfully with id %d!", session.Title, session.ID)
 	},
 }
@@ -51,12 +51,12 @@ var focusListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sessions, err := focusService.ListSessions()
 		if err != nil {
-			PrintErrorln("Error listing focus sessions:", err)
+			utils.PrintErrorln("Error listing focus sessions:", err)
 			ac.Logger.Error().Msgf("Error listing focus sessions: %v", err)
 			return
 		}
 		if len(sessions) == 0 {
-			PrintInfoln("No focus sessions found... Try starting one with 'mindloop focus start <title>'")
+			utils.PrintInfoln("No focus sessions found... Try starting one with 'mindloop focus start <title>'")
 			ac.Logger.Info().Msg("No focus sessions found. Prompting user to start a new focus session.")
 			return
 		}
@@ -67,8 +67,8 @@ var focusListCmd = &cobra.Command{
 		}
 
 		ac.Logger.Info().Msg("Listing all focus sessions.")
-		PrintInfoln("Focus sessions listed below. Note: Duration is in minutes")
-		PrintTable(views)
+		utils.PrintInfoln("Focus sessions listed below. Note: Duration is in minutes")
+		utils.PrintTable(views)
 	},
 }
 
@@ -82,19 +82,19 @@ var focusEndCmd = &cobra.Command{
 		sessionID := args[0]
 		sessionIDInt, err := strconv.Atoi(sessionID)
 		if err != nil {
-			PrintErrorln("Error parsing session ID:", err)
+			utils.PrintErrorln("Error parsing session ID:", err)
 			return
 		}
 
 		session, err := focusService.EndSession(sessionIDInt)
 		if err != nil {
-			PrintErrorln("Error ending focus session:", err)
+			utils.PrintErrorln("Error ending focus session:", err)
 			ac.Logger.Error().Msgf("Error ending focus session: %v", err)
 			return
 		}
 
-		PrintSuccessf("Focus session '%s' ended successfully!\n", session.Title)
-		PrintRocketln("Great work chief!")
+		utils.PrintSuccessf("Focus session '%s' ended successfully!\n", session.Title)
+		utils.PrintRocketln("Great work chief!")
 		ac.Logger.Info().Msgf("Focus session '%s' ended successfully!", session.Title)
 	},
 }
@@ -109,24 +109,24 @@ var focusRateCmd = &cobra.Command{
 		sessionID := args[0]
 		sessionIDInt, err := strconv.Atoi(sessionID)
 		if err != nil {
-			PrintErrorln("Error parsing session ID:", err)
+			utils.PrintErrorln("Error parsing session ID:", err)
 			return
 		}
 
 		rating, err := strconv.Atoi(args[1])
 		if err != nil {
-			PrintWarnln("Rating must be an integer.")
+			utils.PrintWarnln("Rating must be an integer.")
 			return
 		}
 
 		session, err := focusService.RateSession(sessionIDInt, rating)
 		if err != nil {
-			PrintErrorln("Error saving rating:", err)
+			utils.PrintErrorln("Error saving rating:", err)
 			ac.Logger.Error().Msgf("Error saving rating for focus session: %v", err)
 			return
 		}
 
-		PrintSuccessf("'%s' session rated successfully with a score of %d!\n", session.Title, session.Rating)
+		utils.PrintSuccessf("'%s' session rated successfully with a score of %d!\n", session.Title, session.Rating)
 		ac.Logger.Info().Msgf("Focus session '%s' rated successfully with a score of %d!", session.Title, session.Rating)
 	},
 }

--- a/cmd/cli/habit.go
+++ b/cmd/cli/habit.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/snehmatic/mindloop/internal/core/habit"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -36,17 +36,17 @@ var habitAddCmd = &cobra.Command{
 	Example: `mindloop habit add "Excercise" "Need to be fit!" 1 --daily
 	mindloop habit add -i`,
 	Run: func(cmd *cobra.Command, args []string) {
-		PrintRocketln("Great initiative! Adding a new habit...")
+		utils.PrintRocketln("Great initiative! Adding a new habit...")
 		newHabit := &models.Habit{}
 		newHabit.SetDefaults()
 
 		if *interactive {
-			PrintInfoln("Interactive mode enabled for adding habit...")
+			utils.PrintInfoln("Interactive mode enabled for adding habit...")
 			BuildHabitFromInteractiveMode(newHabit)
 		} else {
 			// non interactive mode
 			if len(args) < 3 {
-				PrintWarnln("Please provide habit details. Ex. 'mindloop habit add <title> <description> <target_count>' --weekly or --daily(default)")
+				utils.PrintWarnln("Please provide habit details. Ex. 'mindloop habit add <title> <description> <target_count>' --weekly or --daily(default)")
 				ac.Logger.Error().
 					Interface("habit", newHabit).
 					Msg("Failed to add habit: missing arguments")
@@ -60,7 +60,7 @@ var habitAddCmd = &cobra.Command{
 					Interface("habit", newHabit).
 					Err(err).
 					Msg("Failed to convert target count to integer")
-				PrintErrorln("Invalid target count. Please provide a valid integer.")
+				utils.PrintErrorln("Invalid target count. Please provide a valid integer.")
 				return
 			}
 			newHabit.TargetCount = targetCount
@@ -74,7 +74,7 @@ var habitAddCmd = &cobra.Command{
 				Interface("habit", newHabit).
 				Err(err).
 				Msg("Failed to add habit")
-			PrintErrorln("Failed to add habit:", err)
+			utils.PrintErrorln("Failed to add habit:", err)
 			return
 		}
 
@@ -82,7 +82,7 @@ var habitAddCmd = &cobra.Command{
 			Interface("habit", newHabit).
 			Msg("Habit added successfully")
 
-		PrintSuccessf("Habit '%s' added successfully with ID: %d\n", newHabit.Title, newHabit.ID)
+		utils.PrintSuccessf("Habit '%s' added successfully with ID: %d\n", newHabit.Title, newHabit.ID)
 	},
 }
 
@@ -96,7 +96,7 @@ var habitDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for deletion")
-			PrintWarnln("Please provide the habit ID to delete.")
+			utils.PrintWarnln("Please provide the habit ID to delete.")
 			return
 		}
 		habitID := args[0]
@@ -108,21 +108,21 @@ var habitDeleteCmd = &cobra.Command{
 		habit, err := habitService.GetHabit(habitID)
 		if err != nil {
 			ac.Logger.Error().Msg("Habit not found")
-			PrintErrorln("Habit not found:", err)
+			utils.PrintErrorln("Habit not found:", err)
 			return
 		}
 
 		err = habitService.DeleteHabit(habitID)
 		if err != nil {
 			ac.Logger.Error().Err(err).Msg("Failed to delete habit")
-			PrintErrorln("Failed to delete habit:", err)
+			utils.PrintErrorln("Failed to delete habit:", err)
 			return
 		}
 
 		ac.Logger.Info().
 			Interface("habit", habit).
 			Msg("Habit deleted successfully")
-		PrintSuccessf("Habit '%s' deleted successfully.\n", habit.Title)
+		utils.PrintSuccessf("Habit '%s' deleted successfully.\n", habit.Title)
 	},
 }
 
@@ -135,7 +135,7 @@ var habitUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for update")
-			PrintWarnln("Please provide the habit ID to update.")
+			utils.PrintWarnln("Please provide the habit ID to update.")
 			return
 		}
 		habitId := args[0]
@@ -143,13 +143,13 @@ var habitUpdateCmd = &cobra.Command{
 		habit, err := habitService.GetHabit(habitId)
 		if err != nil {
 			ac.Logger.Error().Msg("Habit not found")
-			PrintErrorln("Habit not found:", err)
+			utils.PrintErrorln("Habit not found:", err)
 			return
 		}
 
-		PrintInfof("Updating habit '%s'...\n", habit.Title)
-		PrintTable([]models.HabitView{models.ToHabitView(*habit)})
-		PrintInfoln("Entering interactive mode to update Habit (Press Enter to keep current field intact)")
+		utils.PrintInfof("Updating habit '%s'...\n", habit.Title)
+		utils.PrintTable([]models.HabitView{models.ToHabitView(*habit)})
+		utils.PrintInfoln("Entering interactive mode to update Habit (Press Enter to keep current field intact)")
 		ac.Logger.Info().
 			Interface("habit", habit).
 			Msg("Entering interactive mode to update habit")
@@ -160,14 +160,14 @@ var habitUpdateCmd = &cobra.Command{
 		err = habitService.UpdateHabit(habit)
 		if err != nil {
 			ac.Logger.Error().Err(err).Msg("Failed to update habit")
-			PrintErrorln("Failed to update habit:", err)
+			utils.PrintErrorln("Failed to update habit:", err)
 			return
 		}
 
 		ac.Logger.Info().
 			Interface("habit", habit).
 			Msg("Habit updated successfully")
-		PrintSuccessf("Habit '%s' updated successfully.\n", habit.Title)
+		utils.PrintSuccessf("Habit '%s' updated successfully.\n", habit.Title)
 	},
 }
 
@@ -177,12 +177,12 @@ var habitListCmd = &cobra.Command{
 	Example: `mindloop habit list`,
 	Aliases: []string{"l"},
 	Run: func(cmd *cobra.Command, args []string) {
-		PrintInfoln("Keep calm, fetching habits...")
+		utils.PrintInfoln("Keep calm, fetching habits...")
 		ac.Logger.Info().Msg("Fetching habits...")
 
 		intervalFilter := models.IntervalType("")
 		if !*daily && !*weekly { // nothing selected via flags
-			PrintInfoln("No interval filter applied. Showing all habit logs.")
+			utils.PrintInfoln("No interval filter applied. Showing all habit logs.")
 			ac.Logger.Info().Msg("No interval filter applied. Showing all habit logs.")
 		} else {
 			intervalFilter = GetIntervalFromFlag()
@@ -191,7 +191,7 @@ var habitListCmd = &cobra.Command{
 		habits, err := habitService.ListHabits(intervalFilter)
 		if err != nil {
 			ac.Logger.Error().Err(err).Msg("Failed to retrieve habits")
-			PrintErrorln("Failed to retrieve habits:", err)
+			utils.PrintErrorln("Failed to retrieve habits:", err)
 			return
 		}
 
@@ -199,7 +199,7 @@ var habitListCmd = &cobra.Command{
 		for _, habit := range habits {
 			habitViews = append(habitViews, models.ToHabitView(habit))
 		}
-		PrintTable(habitViews)
+		utils.PrintTable(habitViews)
 	},
 }
 
@@ -212,7 +212,7 @@ var habitLogCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for logging")
-			PrintWarnln("Please provide the habit ID to log.")
+			utils.PrintWarnln("Please provide the habit ID to log.")
 			return
 		}
 		habitID := args[0]
@@ -220,20 +220,20 @@ var habitLogCmd = &cobra.Command{
 		habit, log, err := habitService.LogHabit(habitID)
 		if err != nil {
 			if err.Error() == "habit already completed for interval" {
-				PrintRocketf("Habit already completed. No need to log again.\n")
+				utils.PrintRocketf("Habit already completed. No need to log again.\n")
 				return
 			}
 			ac.Logger.Error().Err(err).Msg("Failed to log habit")
-			PrintErrorln("Failed to log habit:", err)
+			utils.PrintErrorln("Failed to log habit:", err)
 			return
 		}
 
 		ac.Logger.Info().
 			Interface("habit", habit).
 			Msgf("Habit %s logged %d/%d times in %s interval", habit.Title, log.ActualCount, habit.TargetCount, habit.Interval)
-		PrintLoadingf("Habit %s logged %d/%d times in %s interval.\n", habit.Title, log.ActualCount, habit.TargetCount, habit.Interval)
-		PrintInfof("Use 'mindloop habit unlog <id>' to mark it as undone, and reset to 0/%d.\n", habit.TargetCount)
-		PrintSuccessf("Habit '%s' logged successfully.\n", habit.Title)
+		utils.PrintLoadingf("Habit %s logged %d/%d times in %s interval.\n", habit.Title, log.ActualCount, habit.TargetCount, habit.Interval)
+		utils.PrintInfof("Use 'mindloop habit unlog <id>' to mark it as undone, and reset to 0/%d.\n", habit.TargetCount)
+		utils.PrintSuccessf("Habit '%s' logged successfully.\n", habit.Title)
 	},
 }
 
@@ -247,7 +247,7 @@ var habitUnLogCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for unlogging")
-			PrintWarnln("Please provide the habit ID to unlog.")
+			utils.PrintWarnln("Please provide the habit ID to unlog.")
 			return
 		}
 		habitID := args[0]
@@ -255,15 +255,15 @@ var habitUnLogCmd = &cobra.Command{
 		habit, err := habitService.UnlogHabit(habitID)
 		if err != nil {
 			ac.Logger.Error().Err(err).Msg("Failed to unlog habit")
-			PrintErrorln("Failed to unlog habit:", err)
+			utils.PrintErrorln("Failed to unlog habit:", err)
 			return
 		}
 
 		ac.Logger.Info().
 			Interface("habit", habit).
 			Msg("Habit unlogged successfully")
-		PrintSuccessf("Habit '%s' unlogged successfully. Reset to 0/%d.\n", habit.Title, habit.TargetCount)
-		PrintInfoln("Use 'mindloop habit log <id>' to mark it as done again.")
+		utils.PrintSuccessf("Habit '%s' unlogged successfully. Reset to 0/%d.\n", habit.Title, habit.TargetCount)
+		utils.PrintInfoln("Use 'mindloop habit log <id>' to mark it as done again.")
 	},
 }
 
@@ -273,11 +273,11 @@ var habitLogShowCmd = &cobra.Command{
 	Aliases: []string{"status", "check", "stats"},
 	Short:   "Check habit logs show -w",
 	Run: func(cmd *cobra.Command, args []string) {
-		PrintRocketln("'show me the logs'? Here you go Chief...")
+		utils.PrintRocketln("'show me the logs'? Here you go Chief...")
 
 		intervalFilter := models.IntervalType("")
 		if !*daily && !*weekly { // nothing selected via flags
-			PrintInfoln("No interval filter applied. Showing all habit logs.")
+			utils.PrintInfoln("No interval filter applied. Showing all habit logs.")
 			ac.Logger.Info().Msg("No interval filter applied. Showing all habit logs.")
 			intervalFilter = "" // no filter
 		} else {
@@ -287,17 +287,17 @@ var habitLogShowCmd = &cobra.Command{
 		habitLogs, err := habitService.ListHabitLogs(intervalFilter)
 		if err != nil {
 			ac.Logger.Error().Err(err).Msg("Failed to retrieve habit logs")
-			PrintErrorln("Failed to retrieve habit logs:", err)
+			utils.PrintErrorln("Failed to retrieve habit logs:", err)
 			return
 		}
 
 		if len(habitLogs) == 0 {
-			PrintInfoln("Ruh-roh! No habit logs found. Start logging habits with 'mindloop habit log <id>'")
+			utils.PrintInfoln("Ruh-roh! No habit logs found. Start logging habits with 'mindloop habit log <id>'")
 			return
 		}
 
 		habitLogViews := models.ToHabitLogViews(habitLogs)
-		PrintTable(habitLogViews)
+		utils.PrintTable(habitLogViews)
 	},
 }
 
@@ -327,7 +327,7 @@ func GetIntervalFromFlag() models.IntervalType {
 	} else if *weekly {
 		return models.Weekly
 	}
-	PrintInfoln("Defaulting to daily interval. Use -w or -d to set weekly or daily respectively.")
+	utils.PrintInfoln("Defaulting to daily interval. Use -w or -d to set weekly or daily respectively.")
 	return models.Daily
 }
 
@@ -372,7 +372,7 @@ func BuildHabitFromInteractiveMode(hb *models.Habit) *models.Habit {
 				ac.Logger.Error().
 					Interface("habit", hb).
 					Msg("Invalid interval type.")
-				PrintWarnln("Invalid interval type. Retry with 'daily' or 'weekly'.")
+				utils.PrintWarnln("Invalid interval type. Retry with 'daily' or 'weekly'.")
 				continue
 			}
 			hb.Interval = models.IntervalType(interval)

--- a/cmd/cli/intent.go
+++ b/cmd/cli/intent.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"github.com/snehmatic/mindloop/internal/core/intent"
 	"github.com/snehmatic/mindloop/internal/utils"
-	. "github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -32,12 +31,12 @@ var intentStartCmd = &cobra.Command{
 		// start the intent
 		intent, err := intentService.StartIntent(args[0])
 		if err != nil {
-			PrintErrorln("Error starting intent:", err)
+			utils.PrintErrorln("Error starting intent:", err)
 			ac.Logger.Error().Msgf("Error starting intent: %v", err)
-			PrintInfoln("Please try again or check your database connection.")
+			utils.PrintInfoln("Please try again or check your database connection.")
 			return
 		}
-		PrintSuccessf("Intent '%s' started successfully with id %d!\n", intent.Name, intent.ID)
+		utils.PrintSuccessf("Intent '%s' started successfully with id %d!\n", intent.Name, intent.ID)
 		ac.Logger.Info().Msgf("Intent '%s' started successfully with id %d!", intent.Name, intent.ID)
 	},
 }
@@ -50,13 +49,13 @@ var intentListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		intents, err := intentService.ListIntents()
 		if err != nil {
-			PrintErrorln("Error fetching intents:", err)
+			utils.PrintErrorln("Error fetching intents:", err)
 			ac.Logger.Error().Msgf("Error fetching intents: %v", err)
-			PrintInfoln("Please check your database connection or try again later.")
+			utils.PrintInfoln("Please check your database connection or try again later.")
 			return
 		}
 		if len(intents) == 0 {
-			PrintInfoln("No intents found... Try starting one with 'mindloop intent start <name>'")
+			utils.PrintInfoln("No intents found... Try starting one with 'mindloop intent start <name>'")
 			ac.Logger.Info().Msg("No intents found. Prompting user to start a new intent.")
 			return
 		}
@@ -78,13 +77,13 @@ var intentCurrentCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		intents, err := intentService.ListActiveIntents()
 		if err != nil {
-			PrintErrorln("Error fetching active intents:", err)
+			utils.PrintErrorln("Error fetching active intents:", err)
 			ac.Logger.Error().Msgf("Error fetching active intents: %v", err)
-			PrintInfoln("Please check your database connection or try again later.")
+			utils.PrintInfoln("Please check your database connection or try again later.")
 			return
 		}
 		if len(intents) == 0 {
-			PrintInfoln("No active intents found. To get all intents, use 'mindloop intent list'")
+			utils.PrintInfoln("No active intents found. To get all intents, use 'mindloop intent list'")
 			ac.Logger.Info().Msg("No active intents found. Prompting user to list all intents.")
 			return
 		}
@@ -93,7 +92,7 @@ var intentCurrentCmd = &cobra.Command{
 		for _, i := range intents {
 			views = append(views, models.ToIntentView(i))
 		}
-		PrintTable(views)
+		utils.PrintTable(views)
 		ac.Logger.Info().Msgf("Listed %d active intents successfully.", len(intents))
 	},
 }
@@ -105,21 +104,21 @@ var intentEndCmd = &cobra.Command{
 	Example: `mindloop intent end 10`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			PrintWarnln("Please provide the intent ID to end.")
+			utils.PrintWarnln("Please provide the intent ID to end.")
 			ac.Logger.Warn().Msg("No intent ID provided for ending intent.")
 			return
 		}
 
 		intent, err := intentService.EndIntent(args[0])
 		if err != nil {
-			PrintErrorln("Error ending intent:", err)
+			utils.PrintErrorln("Error ending intent:", err)
 			ac.Logger.Error().Msgf("Error ending intent with ID %s: %v", args[0], err)
 			return
 		}
 
 		ac.Logger.Info().Msgf("Intent '%s' ended successfully!", intent.Name)
 		intentView := models.ToIntentView(*intent)
-		PrintTable([]models.IntentView{intentView})
+		utils.PrintTable([]models.IntentView{intentView})
 	},
 }
 

--- a/cmd/cli/journal.go
+++ b/cmd/cli/journal.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/snehmatic/mindloop/internal/core/journal"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -32,31 +32,31 @@ var journalNewCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			PrintWarnln("Please provide a journal title.")
+			utils.PrintWarnln("Please provide a journal title.")
 			return
 		}
-		PrintRocketln("Let's capture your thoughts! Opening your editor...")
-		content, err := CaptureJournalWithEditor()
+		utils.PrintRocketln("Let's capture your thoughts! Opening your editor...")
+		content, err := utils.CaptureJournalWithEditor()
 		if err != nil {
-			PrintErrorln("Error capturing journal:", err)
+			utils.PrintErrorln("Error capturing journal:", err)
 			return
 		}
 		if content == "" {
-			PrintWarnln("Empty journal. Nothing saved.")
+			utils.PrintWarnln("Empty journal. Nothing saved.")
 			return
 		}
 
-		PrintInfoln("Saving your journal entry...")
+		utils.PrintInfoln("Saving your journal entry...")
 		// Mood handling is now done in the service if empty, but we pass the flag value
 		err = journalService.CreateEntry(args[0], content, *mood)
 		if err != nil {
-			PrintErrorln("Failed to save journal:", err)
+			utils.PrintErrorln("Failed to save journal:", err)
 			return
 		}
 
 		ac.Logger.Info().Msgf("Journal entry '%s' saved with mood '%s'.", args[0], *mood)
-		PrintInfoln("Your journal entry has been saved successfully!")
-		PrintSuccessln("Journal entry saved.")
+		utils.PrintInfoln("Your journal entry has been saved successfully!")
+		utils.PrintSuccessln("Journal entry saved.")
 	},
 }
 
@@ -66,27 +66,27 @@ var journalListCmd = &cobra.Command{
 	Example: `mindloop journal list`,
 	Aliases: []string{"l"},
 	Run: func(cmd *cobra.Command, args []string) {
-		PrintRocketln("Fetching your journal entries...")
+		utils.PrintRocketln("Fetching your journal entries...")
 
 		entries, err := journalService.ListEntries()
 		if err != nil {
-			PrintErrorln("Failed to retrieve journal entries:", err)
+			utils.PrintErrorln("Failed to retrieve journal entries:", err)
 			return
 		}
 		if len(entries) == 0 {
-			PrintInfoln("No journal entries found. Try creating one with 'mindloop journal new <title>'.")
+			utils.PrintInfoln("No journal entries found. Try creating one with 'mindloop journal new <title>'.")
 			return
 		}
 
-		PrintInfoln("Your journal entries:")
+		utils.PrintInfoln("Your journal entries:")
 
 		var entryViews []models.JournalEntryView
 		for _, entry := range entries {
 			entryViews = append(entryViews, models.ToJournalEntryView(entry))
 		}
-		PrintTable(entryViews)
+		utils.PrintTable(entryViews)
 
-		PrintInfoln("To view a specific entry, use 'mindloop journal view <id>'.")
+		utils.PrintInfoln("To view a specific entry, use 'mindloop journal view <id>'.")
 	},
 }
 
@@ -99,7 +99,7 @@ var journalViewCmd = &cobra.Command{
 		id := args[0]
 		entry, err := journalService.GetEntry(id)
 		if err != nil {
-			PrintErrorln("Journal entry not found:", err)
+			utils.PrintErrorln("Journal entry not found:", err)
 			ac.Logger.Error().Msgf("Journal entry not found: %v", err)
 			return
 		}
@@ -120,30 +120,30 @@ var journalDeleteCmd = &cobra.Command{
 
 		entry, err := journalService.GetEntry(id)
 		if err != nil {
-			PrintErrorln("Journal entry not found:", err)
+			utils.PrintErrorln("Journal entry not found:", err)
 			ac.Logger.Error().Msgf("Journal entry not found: %v", err)
 			return
 		}
 
-		PrintInfof("Are you sure you want to delete journal entry with Title '%s'?\n", entry.Title)
-		PrintInfoln("This action cannot be undone. Type 'yes' to confirm.")
+		utils.PrintInfof("Are you sure you want to delete journal entry with Title '%s'?\n", entry.Title)
+		utils.PrintInfoln("This action cannot be undone. Type 'yes' to confirm.")
 		var confirmation string
 		_, _ = fmt.Scanln(&confirmation)
 		if confirmation != "yes" {
-			PrintWarnln("Deletion cancelled.")
+			utils.PrintWarnln("Deletion cancelled.")
 			ac.Logger.Warn().Msgf("Deletion of journal entry with ID %s cancelled by user.", id)
 			return
 		}
 
-		PrintRocketf("Deleting journal entry '%s'\n", entry.Title)
+		utils.PrintRocketf("Deleting journal entry '%s'\n", entry.Title)
 		err = journalService.DeleteEntry(id)
 		if err != nil {
-			PrintErrorln("Failed to delete journal entry:", err)
+			utils.PrintErrorln("Failed to delete journal entry:", err)
 			ac.Logger.Error().Msgf("Failed to delete journal entry with ID %s: %v", id, err)
 			return
 		}
 
-		PrintSuccessln("Journal entry deleted successfully!")
+		utils.PrintSuccessln("Journal entry deleted successfully!")
 		ac.Logger.Info().Msgf("Deleted journal entry with ID %s.", id)
 	},
 }
@@ -160,11 +160,11 @@ func init() {
 
 func PrintJournalEntry(entry models.JournalEntry) {
 	fmt.Println("-------------------------------")
-	PrintInfoln("Title:", entry.Title)
-	PrintInfoln("Mood:", entry.Mood)
-	PrintLoadingln("Date:", entry.CreatedAt.Format("2006-01-02 15:04:05"))
+	utils.PrintInfoln("Title:", entry.Title)
+	utils.PrintInfoln("Mood:", entry.Mood)
+	utils.PrintLoadingln("Date:", entry.CreatedAt.Format("2006-01-02 15:04:05"))
 	fmt.Println("-------------------------------")
 	fmt.Println(entry.Content)
 	fmt.Println("-------------------------------")
-	PrintInfoln("End of journal entry.")
+	utils.PrintInfoln("End of journal entry.")
 }

--- a/cmd/cli/note.go
+++ b/cmd/cli/note.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/snehmatic/mindloop/internal/core/note"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -30,10 +30,10 @@ var noteCmd = &cobra.Command{
 			content := args[0]
 			n, err := noteService.CreateNote(noteTitle, content, noteLabels)
 			if err != nil {
-				PrintErrorln("Error creating note:", err)
+				utils.PrintErrorln("Error creating note:", err)
 				return
 			}
-			PrintSuccessf("Note saved with ID %d!\n", n.ID)
+			utils.PrintSuccessf("Note saved with ID %d!\n", n.ID)
 			return
 		}
 		// If no args, list notes
@@ -51,11 +51,11 @@ var noteListCmd = &cobra.Command{
 func runNoteList(cmd *cobra.Command, args []string) {
 	notes, err := noteService.ListNotes()
 	if err != nil {
-		PrintErrorln("Error listing notes:", err)
+		utils.PrintErrorln("Error listing notes:", err)
 		return
 	}
 	if len(notes) == 0 {
-		PrintInfoln("No notes found. Try 'mindloop note \"your note text\"'")
+		utils.PrintInfoln("No notes found. Try 'mindloop note \"your note text\"'")
 		return
 	}
 
@@ -63,7 +63,7 @@ func runNoteList(cmd *cobra.Command, args []string) {
 	for _, n := range notes {
 		views = append(views, models.ToNoteView(n))
 	}
-	PrintTable(views)
+	utils.PrintTable(views)
 }
 
 var noteNewCmd = &cobra.Command{
@@ -71,22 +71,22 @@ var noteNewCmd = &cobra.Command{
 	Short:   "Create a new note using your default $EDITOR",
 	Run: func(cmd *cobra.Command, args []string) {
 		header := "# Mindloop Note\n# Title: " + noteTitle + "\n# Labels: " + noteLabels + "\n# Write your note below. Lines starting with # will be ignored.\n\n"
-		content, err := CaptureWithEditor("mindloop_note_*.md", header, "")
+		content, err := utils.CaptureWithEditor("mindloop_note_*.md", header, "")
 		if err != nil {
-			PrintErrorln("Error capturing note:", err)
+			utils.PrintErrorln("Error capturing note:", err)
 			return
 		}
 		if content == "" {
-			PrintWarnln("Empty note. Nothing saved.")
+			utils.PrintWarnln("Empty note. Nothing saved.")
 			return
 		}
 
 		n, err := noteService.CreateNote(noteTitle, content, noteLabels)
 		if err != nil {
-			PrintErrorln("Failed to save note:", err)
+			utils.PrintErrorln("Failed to save note:", err)
 			return
 		}
-		PrintSuccessf("Note '%s' saved with ID %d!\n", n.Title, n.ID)
+		utils.PrintSuccessf("Note '%s' saved with ID %d!\n", n.Title, n.ID)
 	},
 }
 
@@ -97,18 +97,18 @@ var noteViewCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		id, err := strconv.Atoi(args[0])
 		if err != nil {
-			PrintErrorln("Invalid ID:", args[0])
+			utils.PrintErrorln("Invalid ID:", args[0])
 			return
 		}
 		n, err := noteService.GetNote(id)
 		if err != nil {
-			PrintErrorln("Note not found:", err)
+			utils.PrintErrorln("Note not found:", err)
 			return
 		}
 		fmt.Println("-------------------------------")
-		PrintInfoln("Title:", n.Title)
-		PrintInfoln("Labels:", n.Labels)
-		PrintLoadingln("Updated:", n.UpdatedAt.Format("2006-01-02 15:04:05"))
+		utils.PrintInfoln("Title:", n.Title)
+		utils.PrintInfoln("Labels:", n.Labels)
+		utils.PrintLoadingln("Updated:", n.UpdatedAt.Format("2006-01-02 15:04:05"))
 		fmt.Println("-------------------------------")
 		fmt.Println(n.Content)
 		fmt.Println("-------------------------------")
@@ -122,28 +122,28 @@ var noteEditCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		id, err := strconv.Atoi(args[0])
 		if err != nil {
-			PrintErrorln("Invalid ID:", args[0])
+			utils.PrintErrorln("Invalid ID:", args[0])
 			return
 		}
 		n, err := noteService.GetNote(id)
 		if err != nil {
-			PrintErrorln("Note not found:", err)
+			utils.PrintErrorln("Note not found:", err)
 			return
 		}
 
 		header := "# Mindloop Note Edit\n# Lines starting with # will be ignored.\n\n"
-		content, err := CaptureWithEditor("mindloop_note_edit_*.md", header, n.Content)
+		content, err := utils.CaptureWithEditor("mindloop_note_edit_*.md", header, n.Content)
 		if err != nil {
-			PrintErrorln("Error capturing note:", err)
+			utils.PrintErrorln("Error capturing note:", err)
 			return
 		}
 
 		_, err = noteService.UpdateNote(id, n.Title, content, n.Labels)
 		if err != nil {
-			PrintErrorln("Failed to update note:", err)
+			utils.PrintErrorln("Failed to update note:", err)
 			return
 		}
-		PrintSuccessln("Note updated.")
+		utils.PrintSuccessln("Note updated.")
 	},
 }
 
@@ -154,15 +154,15 @@ var noteDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		id, err := strconv.Atoi(args[0])
 		if err != nil {
-			PrintErrorln("Invalid ID:", args[0])
+			utils.PrintErrorln("Invalid ID:", args[0])
 			return
 		}
 		err = noteService.DeleteNote(id)
 		if err != nil {
-			PrintErrorln("Error deleting note:", err)
+			utils.PrintErrorln("Error deleting note:", err)
 			return
 		}
-		PrintSuccessln("Note deleted.")
+		utils.PrintSuccessln("Note deleted.")
 	},
 }
 

--- a/cmd/cli/quest.go
+++ b/cmd/cli/quest.go
@@ -7,7 +7,7 @@ import (
 	"github.com/snehmatic/mindloop/internal/core/focus"
 	"github.com/snehmatic/mindloop/internal/core/intent"
 	"github.com/snehmatic/mindloop/internal/core/quest"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -38,16 +38,16 @@ var questStartCmd = &cobra.Command{
 		// 1. Check/Pause active intent
 		activeIntents, err := intentService.ListActiveIntents()
 		if err != nil {
-			PrintErrorln("Error checking active intents:", err)
+			utils.PrintErrorln("Error checking active intents:", err)
 			return
 		}
 		for _, i := range activeIntents {
 			_, err := intentService.PauseIntent(i.ID)
 			if err != nil {
-				PrintErrorln("Error pausing intent:", err)
+				utils.PrintErrorln("Error pausing intent:", err)
 				return
 			}
-			PrintInfof("Paused intent: %s\n", i.Name)
+			utils.PrintInfof("Paused intent: %s\n", i.Name)
 		}
 
 		// 2. Check/Pause active focus session
@@ -55,21 +55,21 @@ var questStartCmd = &cobra.Command{
 		if err == nil && activeSession != nil {
 			_, err := focusService.PauseSession(activeSession.ID)
 			if err != nil {
-				PrintErrorln("Error pausing focus session:", err)
+				utils.PrintErrorln("Error pausing focus session:", err)
 				return
 			}
-			PrintInfof("Paused focus session: %s\n", activeSession.Title)
+			utils.PrintInfof("Paused focus session: %s\n", activeSession.Title)
 		}
 
 		// 3. Start Side Quest
 		q, err := questService.StartQuest(title)
 		if err != nil {
-			PrintErrorln("Error starting quest:", err)
+			utils.PrintErrorln("Error starting quest:", err)
 			return
 		}
 
-		PrintSuccessf("Side Quest '%s' started! Main quest paused.\n", q.Title)
-		PrintRocketln("Adventure awaits!")
+		utils.PrintSuccessf("Side Quest '%s' started! Main quest paused.\n", q.Title)
+		utils.PrintRocketln("Adventure awaits!")
 	},
 }
 
@@ -82,11 +82,11 @@ var questStopCmd = &cobra.Command{
 		// Get active quest
 		q, err := questService.GetActiveQuest()
 		if err != nil {
-			PrintErrorln("Error checking active side quest:", err)
+			utils.PrintErrorln("Error checking active side quest:", err)
 			return
 		}
 		if q == nil {
-			PrintErrorln("No active side quest found.")
+			utils.PrintErrorln("No active side quest found.")
 			return
 		}
 
@@ -96,25 +96,25 @@ var questStopCmd = &cobra.Command{
 		} else {
 			// Interactive mode
 			header := "# Quest Summary\n# Describe what you accomplished:\n\n"
-			note, err = CaptureWithEditor("mindloop_quest_*.md", header, "")
+			note, err = utils.CaptureWithEditor("mindloop_quest_*.md", header, "")
 			if err != nil {
-				PrintErrorln("Error capturing note:", err)
+				utils.PrintErrorln("Error capturing note:", err)
 				return
 			}
 		}
 
 		if note == "" {
-			PrintWarnln("No note provided. Saving with empty note.")
+			utils.PrintWarnln("No note provided. Saving with empty note.")
 		}
 
 		q, err = questService.StopQuest(q.ID, note)
 		if err != nil {
-			PrintErrorln("Error stopping quest:", err)
+			utils.PrintErrorln("Error stopping quest:", err)
 			return
 		}
 
-		PrintSuccessf("Side Quest '%s' complete!\n", q.Title)
-		PrintInfoln("Don't forget to resume your main intent/focus if needed.")
+		utils.PrintSuccessf("Side Quest '%s' complete!\n", q.Title)
+		utils.PrintInfoln("Don't forget to resume your main intent/focus if needed.")
 	},
 }
 
@@ -127,17 +127,17 @@ var questDeleteCmd = &cobra.Command{
 		idStr := args[0]
 		id, err := strconv.Atoi(idStr)
 		if err != nil {
-			PrintErrorln("Invalid ID:", idStr)
+			utils.PrintErrorln("Invalid ID:", idStr)
 			return
 		}
 
 		err = questService.DeleteQuest(uint(id))
 		if err != nil {
-			PrintErrorln("Error deleting quest:", err)
+			utils.PrintErrorln("Error deleting quest:", err)
 			return
 		}
 
-		PrintSuccessf("Quest %d deleted successfully.\n", id)
+		utils.PrintSuccessf("Quest %d deleted successfully.\n", id)
 	},
 }
 
@@ -147,12 +147,12 @@ var questListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		quests, err := questService.ListQuests()
 		if err != nil {
-			PrintErrorln("Error listing quests:", err)
+			utils.PrintErrorln("Error listing quests:", err)
 			return
 		}
 
 		if len(quests) == 0 {
-			PrintInfoln("No quests found.")
+			utils.PrintInfoln("No quests found.")
 			return
 		}
 
@@ -160,7 +160,7 @@ var questListCmd = &cobra.Command{
 		for _, q := range quests {
 			views = append(views, models.ToSideQuestView(q))
 		}
-		PrintTable(views)
+		utils.PrintTable(views)
 	},
 }
 

--- a/cmd/cli/summary.go
+++ b/cmd/cli/summary.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/snehmatic/mindloop/internal/core/summary"
-	. "github.com/snehmatic/mindloop/internal/utils"
+	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
 )
@@ -27,25 +27,25 @@ var summaryCmd = &cobra.Command{
 		summaryService = summary.NewService(gdb)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		PrettyPrintBanner()
+		utils.PrettyPrintBanner()
 		ac.Logger.Info().Msg("Requested productivity summary")
 
 		start, end := GetTimeRangeFromFlags()
 
-		PrintInfoln("Generating summary from", start.Format("02-Jan-2006"), "to", end.Format("02-Jan-2006"))
+		utils.PrintInfoln("Generating summary from", start.Format("02-Jan-2006"), "to", end.Format("02-Jan-2006"))
 
 		report, err := summaryService.GenerateSummary(start, end)
 		if err != nil {
-			PrintErrorln("Error generating summary:", err)
+			utils.PrintErrorln("Error generating summary:", err)
 			ac.Logger.Error().Msgf("Error generating summary: %v", err)
 			return
 		}
 		PrintSummary(report)
 
 		ac.Logger.Info().Msgf("Generated summary from %s to %s", start.Format("02-Jan-2006"), end.Format("02-Jan-2006"))
-		PrintSuccessln("Summary generated successfully!")
+		utils.PrintSuccessln("Summary generated successfully!")
 
-		PrintInfoln("You can also use -d, -w, -m, or -y flags to specify the time range for these summaries. (-d is default)")
+		utils.PrintInfoln("You can also use -d, -w, -m, or -y flags to specify the time range for these summaries. (-d is default)")
 	},
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -81,7 +81,7 @@ func ConnectToDb(appConfig config.Config) (*gorm.DB, error) {
 		)
 		return Conn(connString)
 	default:
-		return nil, fmt.Errorf("Mode selected is invalid!")
+		return nil, fmt.Errorf("mode selected is invalid")
 	}
 }
 

--- a/internal/core/motivation/quote.go
+++ b/internal/core/motivation/quote.go
@@ -83,7 +83,11 @@ func FetchRandomQuote() (*Quote, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch quote: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing response body: %v\n", err)
+		}
+	}()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
 		// Handle external 429

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -257,7 +257,11 @@ func CaptureWithEditor(filenamePattern, header, initialContent string) (string, 
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			logger.Error().Err(err).Msg("failed to remove temp file")
+		}
+	}()
 
 	if header != "" {
 		_, _ = tmpFile.WriteString(header)
@@ -265,7 +269,9 @@ func CaptureWithEditor(filenamePattern, header, initialContent string) (string, 
 	if initialContent != "" {
 		_, _ = tmpFile.WriteString(initialContent)
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		return "", err
+	}
 
 	cmd := exec.Command(editor, tmpFile.Name())
 	cmd.Stdin = os.Stdin

--- a/main.go
+++ b/main.go
@@ -22,7 +22,11 @@ func main() {
 	if err != nil {
 		panic("Failed to open log file: " + err.Error())
 	}
-	defer logFile.Close()
+	defer func() {
+		if err := logFile.Close(); err != nil {
+			panic("Failed to close log file: " + err.Error())
+		}
+	}()
 	log.Init(logFile, zerolog.DebugLevel)
 	logger := log.Get()
 	logger.Info().Msgf("Logging to %s file...", logPath)


### PR DESCRIPTION
This PR addresses the following golangci-lint errors:
- Checked error return values for `os.Remove`, `file.Close`, and `resp.Body.Close`.
- Removed dot imports in `cmd/cli/` files and prefixed utility calls with `utils.`.
- Fixed error string formatting in `db/db.go`.
- Added a `lint` target to the `Makefile` for local linting.

Closes # [if there was an issue number]