### PR TITLE
chore: upgrade Go version to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - name: Test
         run: make test
 
@@ -40,6 +40,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - name: Build
         run: make build

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Mindloop follows a clean architecture pattern, separating core business logic fr
 
 ### Prerequisites
 
-*   [Go](https://go.dev/) 1.24+
+*   [Go](https://go.dev/) 1.26+
 *   [Make](https://www.gnu.org/software/make/)
 
 ### Installation

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snehmatic/mindloop
 
-go 1.24.4
+go 1.26
 
 require (
 	github.com/glebarez/sqlite v1.11.0


### PR DESCRIPTION
Upgrades Go version from 1.24 to 1.26 in:
- go.mod
- GitHub Actions CI workflow
- README.md

Dockerfile already uses 1.26.