### PR TITLE
feat: Make journal and notes cards clickable (fixes #69)

### DIFF
--- a/web/templates/journal.html
+++ b/web/templates/journal.html
@@ -48,7 +48,7 @@
 <div class="entries">
     {{ if .Entries }}
     {{ range .Entries }}
-    <div class="card">
+    <div class="card card-hover" onclick="if(!event.target.closest('button') && !event.target.closest('a')) window.location.href='/journal/view/{{ .ID }}'" style="cursor: pointer;">
         <div id="display-journal-{{ .ID }}">
             <div class="flex-between mb-sm" style="align-items: flex-start;">
                 <div>

--- a/web/templates/notes.html
+++ b/web/templates/notes.html
@@ -42,7 +42,7 @@
         {{ if .Notes }}
         <div class="grid">
             {{ range .Notes }}
-            <div class="card card-hover" style="display: flex; flex-direction: column; justify-content: space-between;">
+            <div class="card card-hover" style="display: flex; flex-direction: column; justify-content: space-between; cursor: pointer;" onclick="if(!event.target.closest('button') && !event.target.closest('a')) window.location.href='/notes/view/{{ .ID }}'">
                 <div id="display-note-{{ .ID }}">
                     <div class="flex-between mb-sm">
                         <h3 style="margin-bottom: 0;">{{ if .Title }}{{ .Title }}{{ else }}Untitled Note{{ end }}</h3>


### PR DESCRIPTION
Fixes #69. Added `onclick` handler to Journal and Notes cards to enter full-view mode, with logic to prevent event bubbling when clicking on child elements like buttons and anchors. Also added cursor styling.