### PR TITLE
feat: implement AuthZ and AuthN (fixes #70)

### DIFF
--- a/api/v1/auth.go
+++ b/api/v1/auth.go
@@ -1,0 +1,88 @@
+package v1
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/snehmatic/mindloop/internal/config"
+)
+
+func hashPassword(password string) string {
+	hash := sha256.Sum256([]byte(password))
+	return hex.EncodeToString(hash[:])
+}
+
+func AuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uc := config.UserConfig{}
+		_ = uc.ReadFromYAML()
+
+		if !uc.AuthConfig.Enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Allow static files and login endpoints to pass through
+		if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, "/static/") || r.URL.Path == "/healthz" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Check for cookie
+		cookie, err := r.Cookie("mindloop_session")
+		if err != nil || cookie.Value != uc.AuthConfig.PasswordHash {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (mlh *MindloopHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		// Just render a simple login template
+		// We might need to ensure layout handles missing partials or we use a separate layout.
+		mlh.renderTemplate(w, "login.html", map[string]interface{}{
+			"Title": "Login",
+		})
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		password := r.FormValue("password")
+		uc := config.UserConfig{}
+		_ = uc.ReadFromYAML()
+
+		if hashPassword(password) == uc.AuthConfig.PasswordHash {
+			http.SetCookie(w, &http.Cookie{
+				Name:     "mindloop_session",
+				Value:    uc.AuthConfig.PasswordHash,
+				Expires:  time.Now().Add(24 * time.Hour),
+				HttpOnly: true,
+				Path:     "/",
+			})
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
+
+		mlh.renderTemplate(w, "login.html", map[string]interface{}{
+			"Title":        "Login",
+			"ErrorMessage": "Invalid password",
+		})
+	}
+}
+
+func (mlh *MindloopHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "mindloop_session",
+		Value:    "",
+		Expires:  time.Now().Add(-1 * time.Hour),
+		HttpOnly: true,
+		Path:     "/",
+	})
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
+}

--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -1094,25 +1094,30 @@ func (mlh *MindloopHandler) HandleSettingsUpdate(w http.ResponseWriter, r *http.
 	ptsJournal, _ := strconv.Atoi(r.FormValue("pts_journal"))
 	ptsQuest, _ := strconv.Atoi(r.FormValue("pts_quest"))
 
-	uc := config.UserConfig{
-		Name:            name,
-		Mode:            mode,
-		EditorWideWidth: r.FormValue("editor_wide_width") == "on",
-		FeatureFlags: config.FeatureFlags{
-			FocusCloud:   r.FormValue("focus_cloud") == "on",
-			HabitCloud:   r.FormValue("habit_cloud") == "on",
-			IntentCloud:  r.FormValue("intent_cloud") == "on",
-			JournalCloud: r.FormValue("journal_cloud") == "on",
-			NoteCloud:    r.FormValue("note_cloud") == "on",
-			Gamification: r.FormValue("gamification") == "on",
-		},
-		PointsConfig: config.PointsConfig{
-			Focus:   ptsFocus,
-			Habit:   ptsHabit,
-			Intent:  ptsIntent,
-			Journal: ptsJournal,
-			Quest:   ptsQuest,
-		},
+	uc := config.UserConfig{}
+	_ = uc.ReadFromYAML()
+
+	uc.Name = name
+	uc.Mode = mode
+	uc.EditorWideWidth = r.FormValue("editor_wide_width") == "on"
+
+	uc.FeatureFlags.FocusCloud = r.FormValue("focus_cloud") == "on"
+	uc.FeatureFlags.HabitCloud = r.FormValue("habit_cloud") == "on"
+	uc.FeatureFlags.IntentCloud = r.FormValue("intent_cloud") == "on"
+	uc.FeatureFlags.JournalCloud = r.FormValue("journal_cloud") == "on"
+	uc.FeatureFlags.NoteCloud = r.FormValue("note_cloud") == "on"
+	uc.FeatureFlags.Gamification = r.FormValue("gamification") == "on"
+
+	uc.PointsConfig.Focus = ptsFocus
+	uc.PointsConfig.Habit = ptsHabit
+	uc.PointsConfig.Intent = ptsIntent
+	uc.PointsConfig.Journal = ptsJournal
+	uc.PointsConfig.Quest = ptsQuest
+
+	uc.AuthConfig.Enabled = r.FormValue("auth_enabled") == "on"
+	newPassword := r.FormValue("auth_password")
+	if newPassword != "" {
+		uc.AuthConfig.PasswordHash = hashPassword(newPassword)
 	}
 
 	if mode == "byodb" {

--- a/cmd/cli/auth.go
+++ b/cmd/cli/auth.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/snehmatic/mindloop/internal/config"
+	"github.com/snehmatic/mindloop/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage authentication settings",
+}
+
+var authSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Enable or change local web UI password",
+	Run: func(cmd *cobra.Command, args []string) {
+		uc := config.UserConfig{}
+		if err := uc.ReadFromYAML(); err != nil {
+			utils.PrintErrorln("Failed to read config")
+			return
+		}
+
+		fmt.Print("Enter new password for web UI: ")
+		var password string
+		fmt.Scanln(&password)
+
+		if password == "" {
+			utils.PrintWarnln("Password cannot be empty")
+			return
+		}
+
+		hash := sha256.Sum256([]byte(password))
+		uc.AuthConfig.PasswordHash = hex.EncodeToString(hash[:])
+		uc.AuthConfig.Enabled = true
+		uc.WriteToYAML()
+
+		utils.PrintSuccessln("Password set and authentication enabled for Web UI")
+	},
+}
+
+var authDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable local web UI password protection",
+	Run: func(cmd *cobra.Command, args []string) {
+		uc := config.UserConfig{}
+		if err := uc.ReadFromYAML(); err != nil {
+			utils.PrintErrorln("Failed to read config")
+			return
+		}
+
+		uc.AuthConfig.Enabled = false
+		uc.WriteToYAML()
+
+		utils.PrintSuccessln("Authentication disabled for Web UI")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+	authCmd.AddCommand(authSetupCmd)
+	authCmd.AddCommand(authDisableCmd)
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -39,9 +39,11 @@ func CreateRouter(mlh *v1.MindloopHandler) (*mux.Router, error) {
 	r.PathPrefix("/static/").Handler(http.FileServer(staticFS))
 
 	// Routes
-	r.HandleFunc("/", mlh.HandleHome).Methods("GET")
 	r.HandleFunc("/healthz", mlh.HandleHealthz).Methods("GET")
+	r.HandleFunc("/login", mlh.HandleLogin).Methods("GET", "POST")
+	r.HandleFunc("/logout", mlh.HandleLogout).Methods("GET", "POST")
 
+	r.HandleFunc("/", mlh.HandleHome).Methods("GET")
 	// Journal Routes
 	r.HandleFunc("/journal", mlh.HandleJournalList).Methods("GET")
 	r.HandleFunc("/journal/new", mlh.HandleJournalCreate).Methods("POST")
@@ -105,8 +107,9 @@ func CreateRouter(mlh *v1.MindloopHandler) (*mux.Router, error) {
 	r.HandleFunc("/about", mlh.HandleAbout).Methods("GET")
 	r.HandleFunc("/void", mlh.HandleVoid).Methods("GET")
 
-	return r, nil
-}
+	r.Use(v1.AuthMiddleware)
+
+	return r, nil}
 
 func ServeMindloop(mlh *v1.MindloopHandler) {
 	r, err := CreateRouter(mlh)

--- a/example.env
+++ b/example.env
@@ -2,4 +2,4 @@ DB_HOST=<host>
 DB_PORT=<port>
 DB_USER=<user>
 DB_PASS=<password>
-DB_NAME=mindloop
+DB_NAME=mindloopAUTH_ENABLED=false\nAUTH_PASSWORD_HASH=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,12 @@ type UserConfig struct {
 	DbConfig        DBConfig     `yaml:"db_config"`
 	FeatureFlags    FeatureFlags `yaml:"feature_flags"`
 	PointsConfig    PointsConfig `yaml:"points_config"`
+	AuthConfig      AuthConfig   `yaml:"auth_config"`
+}
+
+type AuthConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	PasswordHash string `yaml:"password_hash"`
 }
 
 type FeatureFlags struct {

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,0 +1,21 @@
+{{ define "content" }}
+<div class="container" style="max-width: 400px; margin: 4rem auto;">
+    <div class="card text-center mb-xl animate-slide-up">
+        <h1 class="mb-sm" style="color: var(--primary);">Login</h1>
+        <p class="text-muted mb-md">Mindloop is locked.</p>
+        
+        {{ if .ErrorMessage }}
+        <div class="alert alert-danger mb-md" style="padding: 0.5rem; border-radius: 4px; background: rgba(255,0,0,0.1); color: var(--danger);">
+            {{ .ErrorMessage }}
+        </div>
+        {{ end }}
+
+        <form action="/login" method="POST">
+            <div class="form-group mb-md">
+                <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required style="text-align: center;">
+            </div>
+            <button type="submit" class="btn btn-primary" style="width: 100%;">Unlock</button>
+        </form>
+    </div>
+</div>
+{{ end }}

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -10,6 +10,34 @@
 
 <form action="/settings/update" method="POST" id="settings-form">
     <div class="flex-col gap-lg">
+        <!-- Security -->
+        <div class="card">
+            <div class="mb-md">
+                <div class="flex-center mb-md gap-sm" style="justify-content: flex-start;">
+                    <i data-lucide="lock" class="icon-sm text-primary"></i>
+                    <h3 class="mb-0">Security</h3>
+                </div>
+            </div>
+
+            <div class="form-group mb-md">
+                <label class="settings-toggle">
+                    <span class="text-sm font-bold">Enable Password Protection</span>
+                    <input type="checkbox" class="toggle-input" name="auth_enabled" id="auth-toggle"
+                        onchange="toggleAuthSettings(this.checked)" {{ if .Config.AuthConfig.Enabled }}checked{{ end }}>
+                </label>
+                <p class="text-sm text-muted mt-xs mb-0">Require a password to access the web UI.</p>
+            </div>
+
+            <div id="auth-settings-container"
+                style="transition: opacity 0.3s ease; {{ if not .Config.AuthConfig.Enabled }}opacity: 0.5; pointer-events: none;{{ end }}">
+                <div class="form-group">
+                    <label for="auth_password">New Password</label>
+                    <input type="password" id="auth_password" name="auth_password" placeholder="Leave blank to keep current password">
+                    <p class="text-sm text-muted mt-xs mb-0">Set or change your local password.</p>
+                </div>
+            </div>
+        </div>
+
         <!-- General & DB -->
         <div class="card">
             <div class="mb-md">
@@ -270,6 +298,16 @@
 
     function togglePointDefinitions(enabled) {
         const container = document.getElementById('points-definition-container');
+        if (enabled) {
+            container.style.opacity = '1';
+            container.style.pointerEvents = 'auto';
+        } else {
+            container.style.opacity = '0.5';
+            container.style.pointerEvents = 'none';
+        }
+    }
+    function toggleAuthSettings(enabled) {
+        const container = document.getElementById('auth-settings-container');
         if (enabled) {
             container.style.opacity = '1';
             container.style.pointerEvents = 'auto';


### PR DESCRIPTION
Fixes #70. Implemented basic local authentication with password hashing. Added `auth` CLI commands (`mindloop auth setup` and `mindloop auth disable`) and updated the Settings page with Security configurations. Created a login middleware to protect routes.