### PR TITLE
feat: implement Routines and Rituals (fixes #71)

### DIFF
--- a/cmd/cli/routine.go
+++ b/cmd/cli/routine.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/snehmatic/mindloop/db"
+	"github.com/snehmatic/mindloop/internal/config"
+	"github.com/snehmatic/mindloop/internal/core/routine"
+	"github.com/snehmatic/mindloop/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var routineCmd = &cobra.Command{
+	Use:   "routine",
+	Short: "Manage daily and weekly routines",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		config.ValidateUserConfig(cmd)
+	},
+}
+
+var routineCreateCmd = &cobra.Command{
+	Use:   "create [title]",
+	Short: "Create a new routine",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		title := args[0]
+		timeOfDay, _ := cmd.Flags().GetString("time")
+
+		appConfig := config.GetConfig()
+		database, err := db.ConnectToDb(*appConfig)
+		if err != nil {
+			utils.PrintErrorln("Failed to connect to database")
+			return
+		}
+
+		svc := routine.NewService(database)
+		r, err := svc.CreateRoutine(title, timeOfDay)
+		if err != nil {
+			utils.PrintErrorln(fmt.Sprintf("Failed to create routine: %v", err))
+			return
+		}
+
+		utils.PrintSuccessln(fmt.Sprintf("Created routine '%s' (ID: %d)", r.Title, r.ID))
+	},
+}
+
+var routineAddHabitCmd = &cobra.Command{
+	Use:   "add-habit [routine_id] [habit_id]",
+	Short: "Add a habit to a routine",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		routineID, err := strconv.ParseUint(args[0], 10, 32)
+		if err != nil {
+			utils.PrintErrorln("Invalid routine ID")
+			return
+		}
+		habitID, err := strconv.ParseUint(args[1], 10, 32)
+		if err != nil {
+			utils.PrintErrorln("Invalid habit ID")
+			return
+		}
+
+		appConfig := config.GetConfig()
+		database, err := db.ConnectToDb(*appConfig)
+		if err != nil {
+			utils.PrintErrorln("Failed to connect to database")
+			return
+		}
+
+		svc := routine.NewService(database)
+		err = svc.AddHabitToRoutine(uint(routineID), uint(habitID))
+		if err != nil {
+			utils.PrintErrorln(fmt.Sprintf("Failed to add habit to routine: %v", err))
+			return
+		}
+
+		utils.PrintSuccessln("Added habit to routine successfully")
+	},
+}
+
+var routineListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all routines",
+	Run: func(cmd *cobra.Command, args []string) {
+		appConfig := config.GetConfig()
+		database, err := db.ConnectToDb(*appConfig)
+		if err != nil {
+			utils.PrintErrorln("Failed to connect to database")
+			return
+		}
+
+		svc := routine.NewService(database)
+		routines, err := svc.ListRoutines()
+		if err != nil {
+			utils.PrintErrorln("Failed to list routines")
+			return
+		}
+
+		for _, r := range routines {
+			fmt.Printf("[%d] %s (%s) - %d habits\n", r.ID, r.Title, r.TimeOfDay, len(r.Habits))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(routineCmd)
+	routineCmd.AddCommand(routineCreateCmd)
+	routineCmd.AddCommand(routineAddHabitCmd)
+	routineCmd.AddCommand(routineListCmd)
+
+	routineCreateCmd.Flags().String("time", "", "Time of day for the routine (e.g. Morning, Evening)")
+}

--- a/db/db.go
+++ b/db/db.go
@@ -99,6 +99,7 @@ func MigrateDB(db *gorm.DB) error {
 		&models.Note{},
 		&models.SideQuest{},
 		&models.PointTransaction{},
+		&models.Routine{},
 	)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to migrate DB")

--- a/internal/core/routine/routine.go
+++ b/internal/core/routine/routine.go
@@ -1,0 +1,89 @@
+package routine
+
+import (
+	"errors"
+
+	"github.com/snehmatic/mindloop/internal/log"
+	"github.com/snehmatic/mindloop/models"
+	"gorm.io/gorm"
+)
+
+var logger = log.Get()
+
+type Service struct {
+	db *gorm.DB
+}
+
+func NewService(db *gorm.DB) *Service {
+	return &Service{db: db}
+}
+
+func (s *Service) CreateRoutine(title, timeOfDay string) (*models.Routine, error) {
+	r := &models.Routine{
+		Title:     title,
+		TimeOfDay: timeOfDay,
+	}
+	result := s.db.Create(r)
+	if result.Error != nil {
+		logger.Error().Err(result.Error).Msg("Failed to create routine")
+		return nil, result.Error
+	}
+	return r, nil
+}
+
+func (s *Service) ListRoutines() ([]models.Routine, error) {
+	var routines []models.Routine
+	result := s.db.Preload("Habits").Find(&routines)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return routines, nil
+}
+
+func (s *Service) GetRoutine(id uint) (*models.Routine, error) {
+	var routine models.Routine
+	result := s.db.Preload("Habits").First(&routine, id)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, errors.New("routine not found")
+		}
+		return nil, result.Error
+	}
+	return &routine, nil
+}
+
+func (s *Service) UpdateRoutine(r *models.Routine) error {
+	result := s.db.Save(r)
+	return result.Error
+}
+
+func (s *Service) DeleteRoutine(id uint) error {
+	result := s.db.Delete(&models.Routine{}, id)
+	return result.Error
+}
+
+func (s *Service) AddHabitToRoutine(routineID, habitID uint) error {
+	var habit models.Habit
+	if err := s.db.First(&habit, habitID).Error; err != nil {
+		return errors.New("habit not found")
+	}
+
+	habit.RoutineID = &routineID
+	if err := s.db.Save(&habit).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) RemoveHabitFromRoutine(habitID uint) error {
+	var habit models.Habit
+	if err := s.db.First(&habit, habitID).Error; err != nil {
+		return errors.New("habit not found")
+	}
+
+	habit.RoutineID = nil
+	if err := s.db.Save(&habit).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/models/types.go
+++ b/models/types.go
@@ -28,6 +28,21 @@ type Habit struct {
 	Interval    IntervalType `gorm:"type:varchar(100)" json:"interval"`
 	TargetCount int          `gorm:"type:int" json:"target_count"`
 	EndDate     *time.Time   `json:"end_date,omitempty"`
+	RoutineID   *uint        `json:"routine_id,omitempty"`
+}
+
+type Routine struct {
+	gorm.Model
+	Title     string  `gorm:"type:varchar(100)" json:"title"`
+	TimeOfDay string  `gorm:"type:varchar(50)" json:"time_of_day"`
+	Habits    []Habit `gorm:"foreignKey:RoutineID" json:"habits"`
+}
+
+type RoutineView struct {
+	ID        uint        `json:"id"`
+	Title     string      `json:"title"`
+	TimeOfDay string      `json:"time_of_day"`
+	Habits    []HabitView `json:"habits"`
 }
 
 // Defaults for Habit


### PR DESCRIPTION
Fixes #71. Implemented data models, DB migrations, core logic for CRUD on routines, and CLI commands (`mindloop routine create`, `mindloop routine list`, `mindloop routine add-habit`).