### PR TITLE
chore: fix lint issues and add documentation comments

### DIFF
--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -206,6 +206,7 @@ func (mlh *MindloopHandler) HandleHome(w http.ResponseWriter, r *http.Request) {
 		for _, l := range habitLogs {
 			if l.HabitID == h.ID && l.CreatedAt.After(todayStart) && l.ActualCount >= h.TargetCount {
 				completedHabits++
+
 				break
 			}
 		}

--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -98,6 +98,7 @@ func (mlh *MindloopHandler) HandleHabitList(w http.ResponseWriter, r *http.Reque
 
 				if isToday {
 					actual = log.ActualCount
+
 					break
 				}
 			}
@@ -291,6 +292,7 @@ func (mlh *MindloopHandler) getHabitView(id string) (*HabitView, error) {
 
 		if isCurrent {
 			actual = l.ActualCount
+
 			break
 		}
 	}

--- a/cmd/cli/habit.go
+++ b/cmd/cli/habit.go
@@ -24,7 +24,7 @@ var (
 var habitCmd = &cobra.Command{
 	Use:     "habit",
 	Short:   "Manage your habits",
-	Example: `mindloop habit add "Excercise"`,
+	Example: `mindloop habit add "Exercise"`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		habitService = habit.NewService(gdb)
 	},
@@ -34,7 +34,7 @@ var habitCmd = &cobra.Command{
 var habitAddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add a new habit",
-	Example: `mindloop habit add "Excercise" "Need to be fit!" 1 --daily
+	Example: `mindloop habit add "Exercise" "Need to be fit!" 1 --daily
 	mindloop habit add -i`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.PrintRocketln("Great initiative! Adding a new habit...")
@@ -93,7 +93,7 @@ var habitDeleteCmd = &cobra.Command{
 	Short:   "Delete a habit",
 	Aliases: []string{"rm", "remove", "del"},
 	Args:    cobra.ExactArgs(1),
-	Example: `mindloop habit delete "Excercise"`,
+	Example: `mindloop habit delete "Exercise"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for deletion")
@@ -132,7 +132,7 @@ var habitUpdateCmd = &cobra.Command{
 	Use:     "update",
 	Short:   "Update a habit",
 	Aliases: []string{"edit", "modify"},
-	Example: `mindloop habit update "Excercise" --time "1:00 PM"`,
+	Example: `mindloop habit update "Exercise" --time "1:00 PM"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for update")
@@ -209,7 +209,7 @@ var habitLogCmd = &cobra.Command{
 	Use:     "log",
 	Aliases: []string{"done", "complete", "mkd"},
 	Short:   "Log a habit as done",
-	Example: `mindloop habit log "Excercise"`,
+	Example: `mindloop habit log "Exercise"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for logging")
@@ -255,7 +255,7 @@ var habitUnLogCmd = &cobra.Command{
 	Aliases: []string{"undone", "incomplete", "mkud"},
 	Args:    cobra.ExactArgs(1),
 	Short:   "Log a habit as undone",
-	Example: `mindloop habit unlog "Excercise"`,
+	Example: `mindloop habit unlog "Exercise"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ac.Logger.Error().Msg("No habit ID provided for unlogging")
@@ -385,11 +385,14 @@ func BuildHabitFromInteractiveMode(hb *models.Habit) *models.Habit {
 					Interface("habit", hb).
 					Msg("Invalid interval type.")
 				utils.PrintWarnln("Invalid interval type. Retry with 'daily' or 'weekly'.")
+
 				continue
 			}
 			hb.Interval = models.IntervalType(interval)
+
 			break
 		}
+
 		break
 	}
 

--- a/cmd/cli/summary.go
+++ b/cmd/cli/summary.go
@@ -59,20 +59,22 @@ func init() {
 
 func GetTimeRangeFromFlags() (time.Time, time.Time) {
 	now := time.Now()
-	if *year {
+	switch {
+	case *year:
 		return time.Date(now.Year()-1, now.Month(), now.Day(), 0, 0, 0, 0, now.Location()), now
-	} else if *month {
+	case *month:
 		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()), now.AddDate(0, 1, -now.Day())
-	} else if *week {
+	case *week:
 		end := time.Now()
 		start := end.AddDate(0, 0, -7)
 		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
 		return start, end
-	} else if *day {
+	case *day:
+		return now.Add(-24 * time.Hour), now
+	default:
+		// default range "day"
 		return now.Add(-24 * time.Hour), now
 	}
-	// default range "day"
-	return now.Add(-24 * time.Hour), now
 }
 
 func PrintSummary(report models.SummaryReport) {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -31,7 +31,7 @@ const (
 	Port    = "8765"
 )
 
-func CreateRouter(mlh *v1.MindloopHandler) (*mux.Router, error) {
+func CreateRouter(mlh *v1.MindloopHandler) *mux.Router {
 	r := mux.NewRouter()
 
 	// Static files from embedded FS
@@ -105,14 +105,11 @@ func CreateRouter(mlh *v1.MindloopHandler) (*mux.Router, error) {
 	r.HandleFunc("/about", mlh.HandleAbout).Methods("GET")
 	r.HandleFunc("/void", mlh.HandleVoid).Methods("GET")
 
-	return r, nil
+	return r
 }
 
 func ServeMindloop(mlh *v1.MindloopHandler) {
-	r, err := CreateRouter(mlh)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Error creating router")
-	}
+	r := CreateRouter(mlh)
 
 	appConfig := config.GetConfig()
 	srv := &http.Server{
@@ -137,13 +134,12 @@ func ServeMindloop(mlh *v1.MindloopHandler) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatal().Msgf("Server Shutdown Failed:%+v", err)
+		log.Error().Msgf("Server Shutdown Failed:%+v", err)
 	}
 	log.Info().Msg("Server exited properly")
 }
 
 func main() {
-
 	// Parse flags
 	port := flag.String("port", Port, "Port to run the server on")
 	mode := flag.String("mode", "local", "Mode to run the server in (local, byodb, api)")

--- a/db/db.go
+++ b/db/db.go
@@ -1,3 +1,4 @@
+// Package db handles database connection and migrations
 package db
 
 import (
@@ -15,6 +16,7 @@ import (
 
 var logger = log.Get()
 
+// Conn establishes a connection to a PostgreSQL database
 func Conn(connString string) (*gorm.DB, error) {
 	db, err := gorm.Open(postgres.Open(connString), &gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
@@ -35,6 +37,7 @@ func Conn(connString string) (*gorm.DB, error) {
 	return db, nil
 }
 
+// GetLocalDBPath returns the absolute path to the local SQLite database
 func GetLocalDBPath() string {
 	localFile := "mindloop_local.db"
 	if utils.FileExists(localFile) {
@@ -43,6 +46,7 @@ func GetLocalDBPath() string {
 	return config.GetDataDir() + "/" + localFile
 }
 
+// LocalConn establishes a connection to the local SQLite database
 func LocalConn() (*gorm.DB, error) {
 	dbPath := GetLocalDBPath()
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
@@ -64,14 +68,15 @@ func LocalConn() (*gorm.DB, error) {
 	return db, nil
 }
 
+// ConnectToDb connects to the database based on the provided application configuration
 func ConnectToDb(appConfig config.Config) (*gorm.DB, error) {
 	logger.Debug().Msg("Connecting to DB...")
 	switch appConfig.Mode {
 	case config.Local:
 		return LocalConn()
 	case config.ByoDB:
-		fallthrough // as of now, ByoDB is same as Api mode
-	case config.Api:
+		fallthrough // as of now, ByoDB is same as API mode
+	case config.API:
 		connString := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
 			appConfig.DBConfig.Host,
 			appConfig.DBConfig.Port,
@@ -85,10 +90,12 @@ func ConnectToDb(appConfig config.Config) (*gorm.DB, error) {
 	}
 }
 
+// LocalDBFileExists checks if the local SQLite database file exists
 func LocalDBFileExists() bool {
 	return utils.FileExists(GetLocalDBPath())
 }
 
+// MigrateDB performs automatic database schema migrations
 func MigrateDB(db *gorm.DB) error {
 	err := db.AutoMigrate(
 		&models.Intent{},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config manages application-wide and user-specific configurations
 package config
 
 import (
@@ -13,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// GetUserConfigPath returns the path to the user configuration file
 func GetUserConfigPath() string {
 	localFile := "user_config.yaml"
 	if _, err := os.Stat(localFile); err == nil {
@@ -24,6 +26,7 @@ func GetUserConfigPath() string {
 // Version is set during build time via ldflags
 var Version = "dev"
 
+// GetDataDir returns the directory where mindloop data is stored
 func GetDataDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -36,17 +39,19 @@ func GetDataDir() string {
 	return dir
 }
 
+// MindloopMode defines the operating mode of the application
 type MindloopMode string
 
+// AllModes contains the supported operating modes
 var AllModes = [...]string{"local", "byodb", "api"}
 
 var (
-	Local MindloopMode = MindloopMode(AllModes[0])
-	ByoDB MindloopMode = MindloopMode(AllModes[1])
-	Api   MindloopMode = MindloopMode(AllModes[2])
+	Local = MindloopMode(AllModes[0])
+	ByoDB = MindloopMode(AllModes[1])
+	API   = MindloopMode(AllModes[2])
 )
 
-// mindloop Application global configuration
+// Config mindloop Application global configuration
 type Config struct {
 	Mode     MindloopMode
 	Port     string
@@ -56,6 +61,7 @@ type Config struct {
 	Logger   zerolog.Logger
 }
 
+// DBConfig holds database connection parameters
 type DBConfig struct {
 	Host     string
 	Port     string
@@ -65,12 +71,12 @@ type DBConfig struct {
 }
 
 var once sync.Once
-var config *Config
+var cfg *Config
 
+// InitConfig initializes the global application configuration
 func InitConfig(name, mode, port string) {
 	once.Do(func() { // singleton
-
-		config = &Config{
+		cfg = &Config{
 			Name:     name,
 			Port:     port,
 			Mode:     MindloopMode(mode),
@@ -82,13 +88,13 @@ func InitConfig(name, mode, port string) {
 		uc := UserConfig{}
 		if err := uc.ReadFromYAML(); err == nil {
 			if uc.Name != "" {
-				config.UserName = uc.Name
+				cfg.UserName = uc.Name
 			}
 			// Override mode if set in user config and not explicitly overridden by flag (which passed here)
 			// For simplicity, we are not overriding mode here as it might conflict with flags
 			// But we can check if DBConfig is needed
 			if uc.Mode == "byodb" {
-				config.DBConfig = uc.DbConfig
+				cfg.DBConfig = uc.DbConfig
 			}
 		}
 
@@ -98,7 +104,7 @@ func InitConfig(name, mode, port string) {
 			if err != nil {
 				fmt.Printf("error loading .env file: %v\n", err)
 			}
-			config.DBConfig = DBConfig{
+			cfg.DBConfig = DBConfig{
 				Host:     utils.GetEnvOrDie("DB_HOST"),
 				Port:     utils.GetEnvOrDie("DB_PORT"),
 				User:     utils.GetEnvOrDie("DB_USER"),
@@ -107,14 +113,16 @@ func InitConfig(name, mode, port string) {
 			}
 		}
 
-		config.Logger.Info().Msg("Mindloop global config has been set!")
+		cfg.Logger.Info().Msg("Mindloop global config has been set!")
 	})
 }
 
+// GetConfig returns the global configuration object
 func GetConfig() *Config {
-	return config
+	return cfg
 }
 
+// UserConfig represents the persistent user preferences
 type UserConfig struct {
 	Name            string       `yaml:"name"`
 	Mode            string       `yaml:"mode"`
@@ -124,6 +132,7 @@ type UserConfig struct {
 	PointsConfig    PointsConfig `yaml:"points_config"`
 }
 
+// FeatureFlags toggles specific application functionalities
 type FeatureFlags struct {
 	FocusCloud   bool `yaml:"focus_cloud"`
 	HabitCloud   bool `yaml:"habit_cloud"`
@@ -143,6 +152,7 @@ type PointsConfig struct {
 	Quest   int `yaml:"quest"`
 }
 
+// SetDefaults ensures that the UserConfig has sensible default values
 func (uc *UserConfig) SetDefaults() {
 	// Feature flags defaults
 	// Note: in YAML, a missing bool is false.
@@ -170,21 +180,21 @@ func (uc *UserConfig) SetDefaults() {
 	}
 }
 
+// ValidateUserConfig checks if the user configuration is valid and exists
 func ValidateUserConfig(cmd *cobra.Command) {
 	// check if user_config.yaml exists
 	logger := log.Get()
 	configPath := GetUserConfigPath()
 	if utils.FileExists(configPath) {
 		logger.Debug().Msgf("User config exists at %s", configPath)
-	} else {
-		if cmd.Use != "configure" {
-			utils.PrintWarnln("Warn: user config does not exist, create a new one or run `mindloop configure`.")
-			logger.Warn().Msg("User config does not exist, warned user")
-			os.Exit(0)
-		}
+	} else if cmd.Use != "configure" {
+		utils.PrintWarnln("Warn: user config does not exist, create a new one or run `mindloop configure`.")
+		logger.Warn().Msg("User config does not exist, warned user")
+		os.Exit(0)
 	}
 }
 
+// WriteToYAML persists the current UserConfig to a YAML file
 func (uc UserConfig) WriteToYAML() {
 	marshalled, err := yaml.Marshal(uc)
 	if err != nil {
@@ -199,6 +209,7 @@ func (uc UserConfig) WriteToYAML() {
 	utils.PrintSuccessln("User config written to YAML successfully")
 }
 
+// ReadFromYAML loads the UserConfig from a YAML file
 func (uc *UserConfig) ReadFromYAML() error {
 	data, err := os.ReadFile(GetUserConfigPath())
 	if err != nil {

--- a/internal/core/backup/backup.go
+++ b/internal/core/backup/backup.go
@@ -8,15 +8,18 @@ import (
 	"gorm.io/gorm"
 )
 
+// Service handles backup and restore operations for Mindloop
 type Service struct {
 	DB *gorm.DB
 }
 
+// NewService creates a new backup Service instance
 func NewService(db *gorm.DB) *Service {
 	return &Service{DB: db}
 }
 
-type BackupData struct {
+// Data represents the structure of the exported JSON backup file
+type Data struct {
 	Intents        []models.Intent       `json:"intents"`
 	FocusSessions  []models.FocusSession `json:"focus_sessions"`
 	Habits         []models.Habit        `json:"habits"`
@@ -25,8 +28,9 @@ type BackupData struct {
 	Notes          []models.Note         `json:"notes,omitempty"`
 }
 
+// Export saves all application data to a JSON file
 func (s *Service) Export(filePath string) error {
-	var data BackupData
+	var data Data
 
 	s.DB.Find(&data.Intents)
 	s.DB.Find(&data.FocusSessions)
@@ -43,13 +47,14 @@ func (s *Service) Export(filePath string) error {
 	return os.WriteFile(filePath, jsonData, 0644)
 }
 
+// Import restores application data from a JSON file
 func (s *Service) Import(filePath string) error {
 	jsonData, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
 
-	var data BackupData
+	var data Data
 	if err := json.Unmarshal(jsonData, &data); err != nil {
 		return err
 	}

--- a/internal/core/focus/focus.go
+++ b/internal/core/focus/focus.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Service handles the logic for managing focus sessions
 type Service struct {
 	DB *gorm.DB
 }

--- a/internal/core/habit/habit.go
+++ b/internal/core/habit/habit.go
@@ -250,18 +250,20 @@ func (s *Service) CalculateStreak(habitID uint, interval models.IntervalType) (i
 	}
 
 	expectedDate := lastLogDate
+loop:
 	for _, log := range logs {
 		logDate := log.CreatedAt.Truncate(24 * time.Hour)
 
-		if logDate.Equal(expectedDate) {
+		switch {
+		case logDate.Equal(expectedDate):
 			if log.ActualCount >= log.TargetCount {
 				streak++
 				expectedDate = expectedDate.AddDate(0, 0, -1)
 			}
-		} else if logDate.After(expectedDate) {
+		case logDate.After(expectedDate):
 			continue
-		} else {
-			break
+		default:
+			break loop
 		}
 	}
 

--- a/internal/core/intent/intent.go
+++ b/internal/core/intent/intent.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Service handles the logic for managing user intents
 type Service struct {
 	DB *gorm.DB
 }

--- a/internal/core/motivation/quote.go
+++ b/internal/core/motivation/quote.go
@@ -1,3 +1,4 @@
+// Package motivation provides inspirational content for the users
 package motivation
 
 import (
@@ -8,6 +9,7 @@ import (
 	"time"
 )
 
+// Quote represents an inspirational quote with its author
 type Quote struct {
 	Text       string `json:"q"`
 	Author     string `json:"a"`
@@ -66,10 +68,12 @@ func FetchRandomQuote() (*Quote, error) {
 			q := *cachedQuote
 			q.RetryAfter = waitTime
 			cacheMu.Unlock()
+
 			return &q, nil
 		}
 
 		cacheMu.Unlock()
+
 		return nil, fmt.Errorf("rate limit reached and no cache available")
 	}
 	cacheMu.Unlock()
@@ -96,8 +100,10 @@ func FetchRandomQuote() (*Quote, error) {
 		if cachedQuote != nil {
 			q := *cachedQuote
 			q.RetryAfter = int(RateWindow.Seconds())
+
 			return &q, nil
 		}
+
 		return nil, fmt.Errorf("upstream API rate limit reached")
 	}
 

--- a/internal/core/note/note.go
+++ b/internal/core/note/note.go
@@ -7,14 +7,17 @@ import (
 	"gorm.io/gorm"
 )
 
+// Service handles business logic for markdown notes
 type Service struct {
 	DB *gorm.DB
 }
 
+// NewService creates a new note Service instance
 func NewService(db *gorm.DB) *Service {
 	return &Service{DB: db}
 }
 
+// CreateNote persists a new markdown note to the database
 func (s *Service) CreateNote(title, content, labels string) (*models.Note, error) {
 	if title == "" && content == "" {
 		return nil, errors.New("note must have a title or content")
@@ -30,6 +33,7 @@ func (s *Service) CreateNote(title, content, labels string) (*models.Note, error
 	return note, nil
 }
 
+// ListNotes retrieves all markdown notes from the database
 func (s *Service) ListNotes() ([]models.Note, error) {
 	var notes []models.Note
 	if err := s.DB.Order("UpdatedAt desc").Find(&notes).Error; err != nil {
@@ -38,6 +42,7 @@ func (s *Service) ListNotes() ([]models.Note, error) {
 	return notes, nil
 }
 
+// GetNote retrieves a single markdown note by its ID
 func (s *Service) GetNote(id int) (*models.Note, error) {
 	var note models.Note
 	if err := s.DB.First(&note, id).Error; err != nil {
@@ -46,6 +51,7 @@ func (s *Service) GetNote(id int) (*models.Note, error) {
 	return &note, nil
 }
 
+// UpdateNote modifies an existing markdown note in the database
 func (s *Service) UpdateNote(id int, title, content, labels string) (*models.Note, error) {
 	note, err := s.GetNote(id)
 	if err != nil {
@@ -60,10 +66,12 @@ func (s *Service) UpdateNote(id int, title, content, labels string) (*models.Not
 	return note, nil
 }
 
+// DeleteNote removes a markdown note from the database by its ID
 func (s *Service) DeleteNote(id int) error {
 	return s.DB.Delete(&models.Note{}, id).Error
 }
 
+// DeleteAll removes all markdown notes from the database
 func (s *Service) DeleteAll() error {
 	return s.DB.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&models.Note{}).Error
 }

--- a/internal/core/routine/routine.go
+++ b/internal/core/routine/routine.go
@@ -1,3 +1,4 @@
+// Package routine manages groupings of habits for specific times of day
 package routine
 
 import (
@@ -18,6 +19,7 @@ func NewService(db *gorm.DB) *Service {
 	return &Service{db: db}
 }
 
+// CreateRoutine persists a new routine to the database
 func (s *Service) CreateRoutine(title, timeOfDay string) (*models.Routine, error) {
 	r := &models.Routine{
 		Title:     title,
@@ -31,6 +33,7 @@ func (s *Service) CreateRoutine(title, timeOfDay string) (*models.Routine, error
 	return r, nil
 }
 
+// ListRoutines retrieves all routines from the database
 func (s *Service) ListRoutines() ([]models.Routine, error) {
 	var routines []models.Routine
 	result := s.db.Preload("Habits").Find(&routines)

--- a/internal/core/task/task.go
+++ b/internal/core/task/task.go
@@ -10,14 +10,17 @@ import (
 
 var logger = log.Get()
 
+// Service handles business logic for tasks and sub-tasks
 type Service struct {
 	db *gorm.DB
 }
 
+// NewService creates a new task Service instance
 func NewService(db *gorm.DB) *Service {
 	return &Service{db: db}
 }
 
+// CreateTask persists a new task to the database
 func (s *Service) CreateTask(title string, intentID, focusID *uint) (*models.Task, error) {
 	t := &models.Task{
 		Title:          title,
@@ -31,6 +34,7 @@ func (s *Service) CreateTask(title string, intentID, focusID *uint) (*models.Tas
 	return t, nil
 }
 
+// CompleteTask marks a task as completed in the database
 func (s *Service) CompleteTask(id uint) error {
 	var task models.Task
 	if err := s.db.First(&task, id).Error; err != nil {
@@ -44,6 +48,7 @@ func (s *Service) CompleteTask(id uint) error {
 	return nil
 }
 
+// ListTasks retrieves all tasks from the database
 func (s *Service) ListTasks() ([]models.Task, error) {
 	var tasks []models.Task
 	if err := s.db.Preload("SubTasks").Find(&tasks).Error; err != nil {
@@ -52,6 +57,7 @@ func (s *Service) ListTasks() ([]models.Task, error) {
 	return tasks, nil
 }
 
+// AddSubTask persists a new sub-task to the database
 func (s *Service) AddSubTask(taskID uint, title string) (*models.SubTask, error) {
 	st := &models.SubTask{
 		TaskID: taskID,
@@ -63,6 +69,7 @@ func (s *Service) AddSubTask(taskID uint, title string) (*models.SubTask, error)
 	return st, nil
 }
 
+// CompleteSubTask marks a sub-task as completed in the database
 func (s *Service) CompleteSubTask(id uint) error {
 	var st models.SubTask
 	if err := s.db.First(&st, id).Error; err != nil {

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,3 +1,4 @@
+// Package log provides a centralized logging utility for Mindloop
 package log
 
 import (
@@ -12,6 +13,7 @@ var (
 	instance zerolog.Logger
 )
 
+// Init initializes the global logger with the specified output and level
 func Init(out io.Writer, level zerolog.Level) {
 	once.Do(func() {
 		zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
@@ -24,6 +26,7 @@ func Init(out io.Writer, level zerolog.Level) {
 	})
 }
 
+// Get returns the global logger instance
 func Get() zerolog.Logger {
 	return instance
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,7 +119,7 @@ func Serve(mlh *v1.MindloopHandler, port string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatal().Msgf("Server Shutdown Failed:%+v", err)
+		log.Error().Msgf("Server Shutdown Failed:%+v", err)
 	}
 	fmt.Println("Server exited properly")
 	log.Info().Msg("Server exited properly")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,3 +1,4 @@
+// Package utils contains general purpose helper functions for Mindloop
 package utils
 
 import (
@@ -39,11 +40,13 @@ var (
 `
 )
 
+// PrettyPrintBanner prints the Mindloop ASCII art banner
 func PrettyPrintBanner() {
 	greenBanner := fmt.Sprintf("%s%s%s", green, banner, reset)
 	fmt.Println(greenBanner)
 }
 
+// PrettyPrint prints any data as a pretty JSON string
 func PrettyPrint(x any) {
 	b, err := json.MarshalIndent(x, "", "  ")
 	if err != nil {
@@ -52,17 +55,20 @@ func PrettyPrint(x any) {
 	fmt.Print(string(b))
 }
 
+// PrintTable renders a slice of structs as a terminal table
 func PrintTable(data interface{}) {
 	v := reflect.ValueOf(data)
 	if v.Kind() != reflect.Slice {
 		fmt.Println("Input must be a slice of structs")
 		logger.Error().Msg("Input to PrintTable must be a slice of structs")
+
 		return
 	}
 
 	if v.Len() == 0 {
 		fmt.Println("No records found.")
 		logger.Info().Msg("len 0 of the provided data slice")
+
 		return
 	}
 
@@ -70,6 +76,7 @@ func PrintTable(data interface{}) {
 	if first.Kind() != reflect.Struct {
 		fmt.Println("Slice elements must be structs, type mismatch")
 		logger.Error().Msg("Slice elements must be structs, type mismatch")
+
 		return
 	}
 
@@ -100,38 +107,47 @@ func PrintTable(data interface{}) {
 	logger.Info().Msgf("Rendered table with %d records of type %s", v.Len(), first.Type())
 }
 
+// PrintSuccessln prints a success message with a checkmark
 func PrintSuccessln(a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, greenTick)
+
 		return
 	}
 	_, _ = fmt.Fprintln(os.Stdout, append([]any{greenTick}, a...)...)
 }
 
+// PrintSuccessf prints a formatted success message with a checkmark
 func PrintSuccessf(format string, a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, greenTick+" "+format, a...)
+
 		return
 	}
 	_, _ = fmt.Fprintf(os.Stdout, greenTick+" "+format, a...)
 }
 
+// PrintRocketln prints a message with a rocket emoji
 func PrintRocketln(a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, rocket)
+
 		return
 	}
 	_, _ = fmt.Fprintln(os.Stdout, append([]any{rocket}, a...)...)
 }
 
+// PrintRocketf prints a formatted message with a rocket emoji
 func PrintRocketf(format string, a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, rocket+" "+format, a...)
+
 		return
 	}
 	_, _ = fmt.Fprintf(os.Stdout, rocket+" "+format, a...)
 }
 
+// PrintInfoln prints an informational message with an info symbol
 func PrintInfoln(a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, bulb)
@@ -140,6 +156,7 @@ func PrintInfoln(a ...any) {
 	_, _ = fmt.Fprintln(os.Stdout, append([]any{bulb}, a...)...)
 }
 
+// PrintInfof prints a formatted informational message with an info symbol
 func PrintInfof(format string, a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, bulb+" "+format, a...)
@@ -148,6 +165,7 @@ func PrintInfof(format string, a ...any) {
 	_, _ = fmt.Fprintf(os.Stdout, bulb+" "+format, a...)
 }
 
+// PrintLoadingln prints a message with a loading/gear symbol
 func PrintLoadingln(a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, timeSand)
@@ -156,6 +174,7 @@ func PrintLoadingln(a ...any) {
 	_, _ = fmt.Fprintln(os.Stdout, append([]any{timeSand}, a...)...)
 }
 
+// PrintLoadingf prints a formatted message with a loading/gear symbol
 func PrintLoadingf(format string, a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, timeSand+" "+format, a...)
@@ -164,6 +183,7 @@ func PrintLoadingf(format string, a ...any) {
 	_, _ = fmt.Fprintf(os.Stdout, timeSand+" "+format, a...)
 }
 
+// PrintWarnln prints a warning message with a warning symbol
 func PrintWarnln(a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, warn)
@@ -172,6 +192,7 @@ func PrintWarnln(a ...any) {
 	_, _ = fmt.Fprintln(os.Stdout, append([]any{warn}, a...)...)
 }
 
+// PrintWarnf prints a formatted warning message with a warning symbol
 func PrintWarnf(format string, a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, warn+" "+format, a...)
@@ -180,6 +201,7 @@ func PrintWarnf(format string, a ...any) {
 	_, _ = fmt.Fprintf(os.Stdout, warn+" "+format, a...)
 }
 
+// PrintErrorln prints an error message with a cross mark
 func PrintErrorln(a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, redCross)
@@ -188,6 +210,7 @@ func PrintErrorln(a ...any) {
 	_, _ = fmt.Fprintln(os.Stdout, append([]any{redCross}, a...)...)
 }
 
+// PrintErrorf prints a formatted error message with a cross mark
 func PrintErrorf(format string, a ...any) {
 	if len(a) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, redCross+" "+format, a...)
@@ -196,12 +219,14 @@ func PrintErrorf(format string, a ...any) {
 	_, _ = fmt.Fprintf(os.Stdout, redCross+" "+format, a...)
 }
 
+// WriteResponse writes a JSON response to the http.ResponseWriter
 func WriteResponse(data interface{}, respWriter http.ResponseWriter, status int) {
 	respWriter.Header().Set("content-type", "application/json; charset=utf-8")
 	respWriter.WriteHeader(status)
 	_ = json.NewEncoder(respWriter).Encode(data)
 }
 
+// GetEnvOrDie retrieves an environment variable or exits if not set
 func GetEnvOrDie(key string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
@@ -210,12 +235,14 @@ func GetEnvOrDie(key string) string {
 	return ""
 }
 
+// FileExists checks if a file exists at the given path
 func FileExists(filename string) bool {
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return false
 	}
 	return true
 }
+// FileWrite writes data to a file
 func FileWrite(filename string, data []byte) error {
 	if err := os.WriteFile(filename, data, 0644); err != nil {
 		logger.Error().Err(err).Str("file", filename).Msg("failed to write file")
@@ -224,6 +251,7 @@ func FileWrite(filename string, data []byte) error {
 	logger.Info().Str("file", filename).Msg("file written successfully")
 	return nil
 }
+// FileRead reads data from a file
 func FileRead(filename string) ([]byte, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
@@ -233,6 +261,7 @@ func FileRead(filename string) ([]byte, error) {
 	logger.Info().Str("file", filename).Msg("file read successfully")
 	return data, nil
 }
+// FileDelete deletes a file at the given path
 func FileDelete(filename string) error {
 	if err := os.Remove(filename); err != nil {
 		logger.Error().Err(err).Str("file", filename).Msg("failed to delete file")
@@ -242,11 +271,13 @@ func FileDelete(filename string) error {
 	return nil
 }
 
+// CaptureJournalWithEditor launches the user's default editor to capture journal content
 func CaptureJournalWithEditor() (string, error) {
 	header := "# Mindloop Journal\n# Write your thoughts below. Lines starting with # will be ignored.\n\n"
 	return CaptureWithEditor("mindloop_journal_*.md", header, "")
 }
 
+// CaptureWithEditor launches the user's default editor to capture content
 func CaptureWithEditor(filenamePattern, header, initialContent string) (string, error) {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {

--- a/models/types.go
+++ b/models/types.go
@@ -1,3 +1,4 @@
+// Package models contains the data structures and UI views for Mindloop
 package models
 
 import (
@@ -12,15 +13,17 @@ import (
 // model definitions reside here
 // request/response structs, etc.
 
+// IntervalType defines the frequency of a habit
 type IntervalType string
 
 var AllIntervalTypes = [...]string{"daily", "weekly"}
 
 var (
-	Daily  IntervalType = IntervalType(AllIntervalTypes[0])
-	Weekly IntervalType = IntervalType(AllIntervalTypes[1])
+	Daily  = IntervalType(AllIntervalTypes[0])
+	Weekly = IntervalType(AllIntervalTypes[1])
 )
 
+// Habit represents a task that the user wants to perform regularly
 type Habit struct {
 	gorm.Model
 	Title       string       `gorm:"type:varchar(100)" json:"title"`
@@ -31,6 +34,7 @@ type Habit struct {
 	RoutineID   *uint        `json:"routine_id,omitempty"`
 }
 
+// Routine groups multiple habits into a specific time of day
 type Routine struct {
 	gorm.Model
 	Title     string  `gorm:"type:varchar(100)" json:"title"`
@@ -38,6 +42,7 @@ type Routine struct {
 	Habits    []Habit `gorm:"foreignKey:RoutineID" json:"habits"`
 }
 
+// RoutineView is a simplified representation of a Routine for the UI
 type RoutineView struct {
 	ID        uint        `json:"id"`
 	Title     string      `json:"title"`
@@ -74,6 +79,7 @@ func (h *Habit) ValidateHabit() error {
 	return nil
 }
 
+// HabitLog records an instance of a habit being performed
 type HabitLog struct {
 	gorm.Model
 	HabitID     uint         `gorm:"not null" json:"habit_id"`
@@ -84,6 +90,7 @@ type HabitLog struct {
 	EndedAt     time.Time    `gorm:"not null" json:"ended_at"`
 }
 
+// HabitLogView is a simplified representation of a HabitLog for the UI
 type HabitLogView struct {
 	ID          uint         `json:"id"`
 	HabitID     uint         `json:"habit_id"`
@@ -112,6 +119,7 @@ func ToHabitLogViews(habitLogs []HabitLog) []HabitLogView {
 	return habitViews
 }
 
+// HabitView is a simplified representation of a Habit for the UI
 type HabitView struct {
 	ID          uint         `json:"id"`
 	Title       string       `json:"title"`
@@ -151,6 +159,7 @@ func IsValidIntervalType(interval string) bool {
 	return false
 }
 
+// Intent represents a high-level goal for the user
 type Intent struct {
 	gorm.Model
 	Name    string     `gorm:"not null" json:"name"`
@@ -158,6 +167,7 @@ type Intent struct {
 	EndedAt *time.Time `json:"ended_at,omitempty"`
 }
 
+// IntentView is a simplified representation of an Intent for the UI
 type IntentView struct {
 	ID      uint
 	Name    string
@@ -180,6 +190,7 @@ func ToIntentView(i Intent) IntentView {
 	}
 }
 
+// FocusSession records a period of deep work
 type FocusSession struct {
 	gorm.Model
 	Title    string    `gorm:"not null" json:"title"`        // e.g., "Work on project"
@@ -189,6 +200,7 @@ type FocusSession struct {
 	Rating   int       `gorm:"default:-1" json:"rating"` // 0 to 10, optional
 }
 
+// FocusSessionView is a simplified representation of a FocusSession for the UI
 type FocusSessionView struct {
 	ID        uint    `json:"id"`
 	Title     string  `json:"title"`
@@ -222,6 +234,7 @@ func ToFocusSessionView(fs FocusSession) FocusSessionView {
 	return fsv
 }
 
+// JournalEntry represents a user's reflective writing
 type JournalEntry struct {
 	gorm.Model
 	Content string `gorm:"type:text" json:"content"`
@@ -229,6 +242,7 @@ type JournalEntry struct {
 	Mood    string `gorm:"type:varchar(50)" json:"mood"` // e.g., happy, sad, neutral
 }
 
+// JournalEntryView is a simplified representation of a JournalEntry for the UI
 type JournalEntryView struct {
 	ID    uint   `json:"id"`
 	Title string `json:"title"`
@@ -245,6 +259,7 @@ func ToJournalEntryView(entry JournalEntry) JournalEntryView {
 	}
 }
 
+// Note represents a quick markdown note
 type Note struct {
 	gorm.Model
 	Title   string `gorm:"type:varchar(200)" json:"title"`
@@ -252,6 +267,7 @@ type Note struct {
 	Labels  string `gorm:"type:varchar(200)" json:"labels"` // comma separated
 }
 
+// NoteView is a simplified representation of a Note for the UI
 type NoteView struct {
 	ID        uint   `json:"id"`
 	Title     string `json:"title"`
@@ -305,6 +321,7 @@ type SummaryReport struct {
 	Intents   []IntentStats
 	Points    PointStats
 }
+// SideQuest represents an ad-hoc task during a focus session
 type SideQuest struct {
 	gorm.Model
 	Title   string     `gorm:"not null" json:"title"`
@@ -313,15 +330,17 @@ type SideQuest struct {
 	EndedAt *time.Time `json:"ended_at,omitempty"`
 }
 
+// Task represents a to-do item linked to an intent or focus session
 type Task struct {
 	gorm.Model
-	Title          string     `gorm:"not null" json:"title"`
-	Status         string     `gorm:"default:pending" json:"status"` // pending, completed
-	IntentID       *uint      `json:"intent_id,omitempty"`
-	FocusSessionID *uint      `json:"focus_session_id,omitempty"`
-	SubTasks       []SubTask  `gorm:"foreignKey:TaskID" json:"sub_tasks"`
+	Title          string    `gorm:"not null" json:"title"`
+	Status         string    `gorm:"default:pending" json:"status"` // pending, completed
+	IntentID       *uint     `json:"intent_id,omitempty"`
+	FocusSessionID *uint     `json:"focus_session_id,omitempty"`
+	SubTasks       []SubTask `gorm:"foreignKey:TaskID" json:"sub_tasks"`
 }
 
+// SubTask is a smaller component of a Task
 type SubTask struct {
 	gorm.Model
 	TaskID uint   `gorm:"not null" json:"task_id"`
@@ -329,6 +348,7 @@ type SubTask struct {
 	Status string `gorm:"default:pending" json:"status"` // pending, completed
 }
 
+// SideQuestView is a simplified representation of a SideQuest for the UI
 type SideQuestView struct {
 	ID      uint   `json:"id"`
 	Title   string `json:"title"`

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,8 +1,11 @@
+// Package web provides embedded static assets and templates
 package web
 
 import (
 	"embed"
 )
 
+// WebFS contains the entire web directory embedded into the binary
+//
 //go:embed templates/* static/*
 var WebFS embed.FS


### PR DESCRIPTION
Fixed various lint issues identified by golangci-lint:
- Fixed `exitAfterDefer` by replacing `log.Fatal` with `log.Error` during server shutdown.
- Fixed `ifElseChain` and `elseif` issues by using `switch` and idiomatic `else if`.
- Added missing documentation comments for exported symbols in many packages.
- Fixed misspellings of "Exercise".
- Added blank lines before `return`, `break`, and `continue` as required by `nlreturn`.
- Fixed ineffective `break` in `CalculateStreak` using a labeled break.
- Renamed internal config variable to avoid shadowing and fix typecheck error.
- Renamed `BackupData` to `Data` to avoid stuttering.
- Removed unused error return from `CreateRouter`.
- Fixed unnecessary leading newlines.