### PR TITLE
feat: completion of parent task will mark subtasks as done 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ] 
   pull_request:
     branches: [ "main" ]
 

--- a/internal/core/task/task.go
+++ b/internal/core/task/task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"errors"
 
+	"github.com/snehmatic/mindloop/internal/config"
 	"github.com/snehmatic/mindloop/internal/core/points"
 	"github.com/snehmatic/mindloop/internal/log"
 	"github.com/snehmatic/mindloop/models"
@@ -14,11 +15,18 @@ var logger = log.Get()
 // Service handles business logic for tasks and sub-tasks
 type Service struct {
 	db *gorm.DB
+	uc *config.UserConfig
 }
 
 // NewService creates a new task Service instance
 func NewService(db *gorm.DB) *Service {
-	return &Service{db: db}
+	uc := config.UserConfig{}
+	err := uc.ReadFromYAML()
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to read user config")
+	}
+
+	return &Service{db: db, uc: &uc}
 }
 
 // CreateTask persists a new task to the database
@@ -38,13 +46,21 @@ func (s *Service) CreateTask(title string, intentID, focusID *uint) (*models.Tas
 // CompleteTask marks a task as completed in the database
 func (s *Service) CompleteTask(id uint, pointsVal int) (bool, error) {
 	var task models.Task
-	if err := s.db.First(&task, id).Error; err != nil {
+	if err := s.db.Preload("SubTasks").First(&task, id).Error; err != nil {
 		return false, errors.New("task not found")
 	}
 
 	task.Status = "completed"
 	if err := s.db.Save(&task).Error; err != nil {
 		return false, err
+	}
+
+	for _, st := range task.SubTasks {
+		if st.Status != "completed" {
+			if _, err := s.CompleteSubTask(st.ID, s.uc.PointsConfig.SubTask); err != nil {
+				logger.Error().Err(err).Uint("subtask_id", st.ID).Msg("Failed to complete subtask while completing task")
+			}
+		}
 	}
 
 	milestoneReached, err := points.AwardPoints(s.db, models.CategoryTask, task.ID, pointsVal)

--- a/internal/core/task/task.go
+++ b/internal/core/task/task.go
@@ -21,12 +21,12 @@ type Service struct {
 // NewService creates a new task Service instance
 func NewService(db *gorm.DB) *Service {
 	uc := config.UserConfig{}
-	err := uc.ReadFromYAML()
-	if err != nil {
-		logger.Fatal().Err(err).Msg("Failed to read user config")
-	}
+	_ = uc.ReadFromYAML()
 
-	return &Service{db: db, uc: &uc}
+	return &Service{
+		db: db,
+		uc: &uc,
+	}
 }
 
 // CreateTask persists a new task to the database


### PR DESCRIPTION
Closes: #111 
Soooo, I've implemented subtask completion when parent task is completed. That's the good part. 
Too much code needed change to be more readible, so i made the change and didn't refactored anything. 

Maybe let's talk about this here? You can move some to issues, and i can work on some. 

My proposition: 
1. config.UserConfig - imo this should be singleton, like config.Config. 
2. task.Service  - user config should be treated as dependency, not passing individual scores to methods     e.g. `func NewService(db *gorm.DB, uc *config.UserConfig) *Service {`.
3. Errors should be at package lvl = easier to compare in tests. 
   e.g. 
```
var (
    ErrSubTaskNotFound = errors.New("subtask not found")
    ErrTaskNotFound    = errors.New("task not found")
)
```

4. Magic strings. 
```
task.Status = "completed"
```
vs
```
const (
    StatusCompleted = "completed"
    StatusPending   = "pending"
)
```
5. Dependency Injection. 

6. Repository pattern for separation of duties, now task have share db and business logic. 
7. Broken tests on fresh fork `make test` (without any changes) 
```
% make test
>  Running tests...
?       github.com/snehmatic/mindloop   [no test files]
✅ User config written to YAML successfully
--- FAIL: TestHabitFlow (0.00s)
    handlers_test.go:129: Log Habit failed/redirected wrong: /habits?success=true

2026/05/14 01:22:55 ./mindloop/internal/core/summary/summary.go:43 SQL logic error: no such table: Task (1)
[0.073ms] [rows:0] SELECT count(*) FROM `Task` WHERE (Status = "completed" AND UpdatedAt >= "2026-05-07 01:22:55.027" AND UpdatedAt <= "2026-05-14 01:22:55.027") AND `Task`.`DeletedAt` IS NULL
FAIL
FAIL    github.com/snehmatic/mindloop/api/v1    0.594s
?       github.com/snehmatic/mindloop/cmd/cli   [no test files]
?       github.com/snehmatic/mindloop/cmd/server        [no test files]
?       github.com/snehmatic/mindloop/db        [no test files]
?       github.com/snehmatic/mindloop/internal/config   [no test files]
?       github.com/snehmatic/mindloop/internal/core/ai  [no test files]
ok      github.com/snehmatic/mindloop/internal/core/backup      (cached)
ok      github.com/snehmatic/mindloop/internal/core/focus       (cached)
ok      github.com/snehmatic/mindloop/internal/core/habit       (cached)
ok      github.com/snehmatic/mindloop/internal/core/intent      (cached)
ok      github.com/snehmatic/mindloop/internal/core/journal     (cached)
?       github.com/snehmatic/mindloop/internal/core/motivation  [no test files]
ok      github.com/snehmatic/mindloop/internal/core/note        (cached)
ok      github.com/snehmatic/mindloop/internal/core/points      (cached)
ok      github.com/snehmatic/mindloop/internal/core/quest       (cached)
?       github.com/snehmatic/mindloop/internal/core/routine     [no test files]
ok      github.com/snehmatic/mindloop/internal/core/summary     (cached)
?       github.com/snehmatic/mindloop/internal/core/task        [no test files]
?       github.com/snehmatic/mindloop/internal/log      [no test files]
?       github.com/snehmatic/mindloop/internal/server   [no test files]
ok      github.com/snehmatic/mindloop/internal/utils    (cached)
?       github.com/snehmatic/mindloop/models    [no test files]
?       github.com/snehmatic/mindloop/web       [no test files]
FAIL
make: *** [test] Error 1
```
8. CI - tests, vet, fmt,  should run also outside main imho. 
9. Missing tests for task. 

That's all for now.