### PR TITLE
Make gamification milestones configurable

### DIFF
--- a/api/v1/handlers_impl.go
+++ b/api/v1/handlers_impl.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/snehmatic/mindloop/internal/config"
 	"github.com/snehmatic/mindloop/internal/core/motivation"
+	"github.com/snehmatic/mindloop/internal/core/points"
 	"github.com/snehmatic/mindloop/models"
 )
 
@@ -1116,6 +1117,7 @@ func (mlh *MindloopHandler) HandleSettingsUpdate(w http.ResponseWriter, r *http.
 	ptsQuest, _ := strconv.Atoi(r.FormValue("pts_quest"))
 	ptsTask, _ := strconv.Atoi(r.FormValue("pts_task"))
 	ptsSubTask, _ := strconv.Atoi(r.FormValue("pts_subtask"))
+	ptsMilestoneInterval, _ := strconv.Atoi(r.FormValue("pts_milestone_interval"))
 
 	uc := config.UserConfig{
 		Name:            name,
@@ -1130,13 +1132,14 @@ func (mlh *MindloopHandler) HandleSettingsUpdate(w http.ResponseWriter, r *http.
 			Gamification: r.FormValue("gamification") == "on",
 		},
 		PointsConfig: config.PointsConfig{
-			Focus:   ptsFocus,
-			Habit:   ptsHabit,
-			Intent:  ptsIntent,
-			Journal: ptsJournal,
-			Quest:   ptsQuest,
-			Task:    ptsTask,
-			SubTask: ptsSubTask,
+			Focus:             ptsFocus,
+			Habit:             ptsHabit,
+			Intent:            ptsIntent,
+			Journal:           ptsJournal,
+			Quest:             ptsQuest,
+			Task:              ptsTask,
+			SubTask:           ptsSubTask,
+			MilestoneInterval: ptsMilestoneInterval,
 		},
 	}
 
@@ -1150,7 +1153,9 @@ func (mlh *MindloopHandler) HandleSettingsUpdate(w http.ResponseWriter, r *http.
 		}
 	}
 
+	uc.PointsConfig.MilestoneInterval = points.NormalizeMilestoneInterval(uc.PointsConfig.MilestoneInterval)
 	uc.WriteToYAML()
+	points.SetMilestoneInterval(uc.PointsConfig.MilestoneInterval)
 
 	// Update in-memory config to reflect changes immediately
 	if mlh.config != nil {

--- a/cmd/cli/configure.go
+++ b/cmd/cli/configure.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/snehmatic/mindloop/internal/config"
+	"github.com/snehmatic/mindloop/internal/gamification"
 	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/snehmatic/mindloop/models"
 	"github.com/spf13/cobra"
@@ -60,7 +62,20 @@ var confCmd = &cobra.Command{
 			}
 		}
 
-		CreateUserConfigYAML(username, mode, dbConfig)
+		milestoneInterval := gamification.DefaultMilestoneInterval
+		fmt.Printf("Please enter your milestone interval [%d]: ", gamification.DefaultMilestoneInterval)
+		var milestoneInput string
+		_, _ = fmt.Scanln(&milestoneInput)
+		if milestoneInput != "" {
+			parsedInterval, err := strconv.Atoi(milestoneInput)
+			if err == nil && parsedInterval > 0 {
+				milestoneInterval = parsedInterval
+			} else {
+				utils.PrintWarnf("Invalid milestone interval. Using default %d.\n", gamification.DefaultMilestoneInterval)
+			}
+		}
+
+		CreateUserConfigYAML(username, mode, dbConfig, milestoneInterval)
 
 		utils.PrintSuccessf("Configuration complete! Your username is set to: %s, using mode: %s\n", username, mode)
 	},
@@ -70,10 +85,13 @@ func init() {
 	rootCmd.AddCommand(confCmd)
 }
 
-func CreateUserConfigYAML(username, mode string, dbConfig *config.DBConfig) {
+func CreateUserConfigYAML(username, mode string, dbConfig *config.DBConfig, milestoneInterval int) {
 	uc := config.UserConfig{
 		Name: username,
 		Mode: mode,
+		PointsConfig: config.PointsConfig{
+			MilestoneInterval: milestoneInterval,
+		},
 	}
 
 	if mode == "byodb" {
@@ -84,6 +102,7 @@ func CreateUserConfigYAML(username, mode string, dbConfig *config.DBConfig) {
 		uc.DbConfig = *dbConfig
 	}
 
+	uc.SetDefaults()
 	uc.WriteToYAML()
 	utils.PrintSuccessln("User config created successfully!")
 	utils.PrintInfof("You can find your config at: %s\n", config.GetUserConfigPath())

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/snehmatic/mindloop/internal/core/intent"
 	"github.com/snehmatic/mindloop/internal/core/journal"
 	"github.com/snehmatic/mindloop/internal/core/note"
+	"github.com/snehmatic/mindloop/internal/core/points"
 	"github.com/snehmatic/mindloop/internal/core/quest"
 	"github.com/snehmatic/mindloop/internal/core/summary"
 	"github.com/snehmatic/mindloop/internal/core/task"
@@ -164,6 +165,7 @@ func main() {
 
 	// Init global config
 	config.InitConfig(AppName, *mode, fmt.Sprintf(":%s", *port))
+	applyMilestoneInterval()
 	appConfig := config.GetConfig()
 
 	database, err := db.ConnectToDb(*appConfig)
@@ -195,4 +197,10 @@ func main() {
 	)
 
 	ServeMindloop(mlh)
+}
+
+func applyMilestoneInterval() {
+	uc := config.UserConfig{}
+	_ = uc.ReadFromYAML()
+	points.SetMilestoneInterval(uc.PointsConfig.MilestoneInterval)
 }

--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -27,6 +27,7 @@ mindloop configure
 This interactive command will guide you through setting up:
 *   **Username**: Your display name.
 *   **Mode**: Choose between `local` (SQLite) or `byodb` (Bring Your Own Database, e.g., PostgreSQL).
+*   **Milestone interval**: How many points are needed between milestone celebrations. The default is `200`.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -64,8 +64,8 @@ Group habits into logical time-blocks (e.g., "Morning Routine").
 ## Gamification & Points
 Turn your productivity into a game with a built-in reward system.
 - **Earn Points**: Get rewarded for completing focus sessions, habits, intents, journals, tasks, sub-tasks, and side quests.
-- **Milestones**: Reach point milestones (every 100 pts) to trigger special full-screen celebration screens.
-- **Customizable Rewards**: Define your own point values for different activities in the Settings.
+- **Milestones**: Reach configurable point milestones (200 pts by default) to trigger special full-screen celebration screens.
+- **Customizable Rewards**: Define your own point values and milestone interval in the Settings.
 - **Visual Progress**: Track your points over time with a dedicated chart in the Summary report.
 - **Celebrations**: Enjoy confetti animations when you finish tasks and reach new heights.
 

--- a/docs/web_ui.md
+++ b/docs/web_ui.md
@@ -71,9 +71,9 @@ Customize your Mindloop experience. You can set your name, choose AI models, man
 ## Gamification & Celebrations
 Mindloop rewards your productivity with points and celebrations.
 - **Points System**: Earn points for every activity completed.
-- **Customization**: Set your own point rewards in the Settings page.
+- **Customization**: Set your own point rewards and milestone interval in the Settings page.
 - **Confetti**: Celebrate small wins with instant confetti animations.
-- **Milestones**: Reach 100-point increments to unlock a special full-screen milestone celebration.
+- **Milestones**: Reach configurable point increments, 200 points by default, to unlock a special full-screen milestone celebration.
 
 ## Dark Mode & Theming
 Mindloop features a classy "Teal and Orange" default theme. It includes a built-in Dark Mode for comfortable viewing in low-light environments. Toggle it using the moon/sun icon in the navigation bar.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
+	"github.com/snehmatic/mindloop/internal/gamification"
 	"github.com/snehmatic/mindloop/internal/log"
 	"github.com/snehmatic/mindloop/internal/utils"
 	"github.com/spf13/cobra"
@@ -97,7 +98,6 @@ func InitConfig(name, mode, port string) {
 				cfg.DBConfig = uc.DbConfig
 			}
 		}
-
 		if mode == "api" {
 			// init DB Config
 			err := godotenv.Load()
@@ -145,13 +145,14 @@ type FeatureFlags struct {
 
 // PointsConfig stores the user-defined point values for each activity type
 type PointsConfig struct {
-	Focus   int `yaml:"focus"`
-	Habit   int `yaml:"habit"`
-	Intent  int `yaml:"intent"`
-	Journal int `yaml:"journal"`
-	Quest   int `yaml:"quest"`
-	Task    int `yaml:"task"`
-	SubTask int `yaml:"subtask"`
+	Focus             int `yaml:"focus"`
+	Habit             int `yaml:"habit"`
+	Intent            int `yaml:"intent"`
+	Journal           int `yaml:"journal"`
+	Quest             int `yaml:"quest"`
+	Task              int `yaml:"task"`
+	SubTask           int `yaml:"subtask"`
+	MilestoneInterval int `yaml:"milestone_interval"`
 }
 
 // SetDefaults ensures that the UserConfig has sensible default values
@@ -186,6 +187,7 @@ func (uc *UserConfig) SetDefaults() {
 	if uc.PointsConfig.SubTask == 0 {
 		uc.PointsConfig.SubTask = 1
 	}
+	uc.PointsConfig.MilestoneInterval = gamification.NormalizeMilestoneInterval(uc.PointsConfig.MilestoneInterval)
 }
 
 // ValidateUserConfig checks if the user configuration is valid and exists

--- a/internal/core/points/points.go
+++ b/internal/core/points/points.go
@@ -1,12 +1,26 @@
 package points
 
 import (
+	"github.com/snehmatic/mindloop/internal/gamification"
 	"github.com/snehmatic/mindloop/models"
 	"gorm.io/gorm"
 )
 
-// MilestoneInterval defines the point increment at which a milestone celebration is triggered
-var MilestoneInterval = 100
+// DefaultMilestoneInterval defines the default point increment for milestone celebrations.
+const DefaultMilestoneInterval = gamification.DefaultMilestoneInterval
+
+// MilestoneInterval defines the point increment at which a milestone celebration is triggered.
+var MilestoneInterval = DefaultMilestoneInterval
+
+// NormalizeMilestoneInterval returns a safe milestone interval value.
+func NormalizeMilestoneInterval(interval int) int {
+	return gamification.NormalizeMilestoneInterval(interval)
+}
+
+// SetMilestoneInterval updates the milestone interval used by AwardPoints.
+func SetMilestoneInterval(interval int) {
+	MilestoneInterval = NormalizeMilestoneInterval(interval)
+}
 
 // AwardPoints creates a new PointTransaction and returns true if a milestone was reached
 func AwardPoints(db *gorm.DB, activityType models.PointCategory, activityID uint, points int) (bool, error) {
@@ -29,8 +43,9 @@ func AwardPoints(db *gorm.DB, activityType models.PointCategory, activityID uint
 	newTotal := currentTotal + points
 
 	// Check if a milestone boundary was crossed
-	currentMilestone := currentTotal / MilestoneInterval
-	newMilestone := newTotal / MilestoneInterval
+	interval := NormalizeMilestoneInterval(MilestoneInterval)
+	currentMilestone := currentTotal / interval
+	newMilestone := newTotal / interval
 
 	return newMilestone > currentMilestone, nil
 }

--- a/internal/core/points/points_test.go
+++ b/internal/core/points/points_test.go
@@ -62,6 +62,45 @@ func TestAwardPoints(t *testing.T) {
 	}
 }
 
+func TestAwardPointsUsesCustomMilestoneInterval(t *testing.T) {
+	db := setupTestDB(t)
+
+	originalInterval := MilestoneInterval
+	SetMilestoneInterval(20)
+	t.Cleanup(func() {
+		MilestoneInterval = originalInterval
+	})
+
+	milestoneReached, err := AwardPoints(db, models.CategoryHabit, 1, 15)
+	if err != nil {
+		t.Fatalf("Expected nil error, got %v", err)
+	}
+	if milestoneReached {
+		t.Errorf("Expected milestone false before custom interval")
+	}
+
+	milestoneReached, err = AwardPoints(db, models.CategoryHabit, 1, 5)
+	if err != nil {
+		t.Fatalf("Expected nil error, got %v", err)
+	}
+	if !milestoneReached {
+		t.Errorf("Expected milestone true after reaching custom interval")
+	}
+}
+
+func TestSetMilestoneIntervalFallsBackToDefault(t *testing.T) {
+	originalInterval := MilestoneInterval
+	t.Cleanup(func() {
+		MilestoneInterval = originalInterval
+	})
+
+	SetMilestoneInterval(0)
+
+	if MilestoneInterval != DefaultMilestoneInterval {
+		t.Errorf("Expected default interval %d, got %d", DefaultMilestoneInterval, MilestoneInterval)
+	}
+}
+
 func TestGetTotalPoints(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/internal/gamification/gamification.go
+++ b/internal/gamification/gamification.go
@@ -1,0 +1,12 @@
+package gamification
+
+// DefaultMilestoneInterval defines the default point increment for milestone celebrations.
+const DefaultMilestoneInterval = 200
+
+// NormalizeMilestoneInterval returns a safe milestone interval value.
+func NormalizeMilestoneInterval(interval int) int {
+	if interval <= 0 {
+		return DefaultMilestoneInterval
+	}
+	return interval
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rs/zerolog"
 	cli "github.com/snehmatic/mindloop/cmd/cli"
 	"github.com/snehmatic/mindloop/internal/config"
+	"github.com/snehmatic/mindloop/internal/core/points"
 	"github.com/snehmatic/mindloop/internal/log"
 )
 
@@ -33,6 +34,13 @@ func main() {
 
 	// Init global config
 	config.InitConfig(AppName, "local", "")
+	applyMilestoneInterval()
 
 	cli.Execute()
+}
+
+func applyMilestoneInterval() {
+	uc := config.UserConfig{}
+	_ = uc.ReadFromYAML()
+	points.SetMilestoneInterval(uc.PointsConfig.MilestoneInterval)
 }

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -359,6 +359,11 @@
                             <input type="number" id="pts_subtask" name="pts_subtask"
                                 value="{{ .Config.PointsConfig.SubTask }}" min="0">
                         </div>
+                        <div class="form-group">
+                            <label for="pts_milestone_interval" class="text-xs">Milestone Interval</label>
+                            <input type="number" id="pts_milestone_interval" name="pts_milestone_interval"
+                                value="{{ .Config.PointsConfig.MilestoneInterval }}" min="1">
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Closes #123.\n\n## Summary\n- add a configurable points_config.milestone_interval with a 200-point default\n- wire the interval into CLI startup, the standalone server, and the web Settings page\n- add CLI configure support, docs, and points tests for custom intervals/default fallback\n\n## Checks\n- go fmt ./...\n- go test ./...\n- go build ./...\n\nNote: make test could not run locally because make is not installed on this Windows machine; go test ./... passed directly.