### PR TITLE
fix: return all models for custom providers in listOpenAIModels

### DIFF
--- a/internal/core/ai/ai.go
+++ b/internal/core/ai/ai.go
@@ -145,9 +145,13 @@ func (s *Service) listGeminiModels(token string) ([]string, error) {
 
 func (s *Service) listOpenAIModels(token, baseURL string) ([]string, error) {
 	url := "https://api.openai.com/v1/models"
+	isCustomProvider := false
+
 	if baseURL != "" {
 		url = strings.TrimSuffix(baseURL, "/") + "/models"
+		isCustomProvider = true
 	}
+
 	req, _ := http.NewRequest("GET", url, nil)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -161,7 +165,7 @@ func (s *Service) listOpenAIModels(token, baseURL string) ([]string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, formatAPIError("OpenAI", resp.StatusCode, body)
+		return nil, formatAPIError("OpenAI/Custom", resp.StatusCode, body)
 	}
 
 	var result struct {
@@ -176,7 +180,9 @@ func (s *Service) listOpenAIModels(token, baseURL string) ([]string, error) {
 
 	var models []string
 	for _, m := range result.Data {
-		if strings.HasPrefix(m.ID, "gpt-") || strings.HasPrefix(m.ID, "o1-") {
+		// Custom providers (e.g. Ollama) don't use OpenAI model prefixes,
+		// so bypass the prefix filter and return all models as-is.
+		if isCustomProvider || strings.HasPrefix(m.ID, "gpt-") || strings.HasPrefix(m.ID, "o1-") {
 			models = append(models, m.ID)
 		}
 	}

--- a/internal/core/ai/ai_test.go
+++ b/internal/core/ai/ai_test.go
@@ -165,3 +165,34 @@ func TestCustomProviderGenerateJournal(t *testing.T) {
 		t.Errorf("Expected 'Journal generated', got '%s'", journal)
 	}
 }
+
+func TestCustomProviderListModels_NonOpenAIModels(t *testing.T) {
+	db := setupTestDB(t)
+	svc := ai.NewService(db)
+
+	// Simulate an Ollama-style response with non-OpenAI model names
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "llama3.1:8b"},
+				{"id": "qwen3-coder:latest"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer mockServer.Close()
+
+	err := svc.SaveSettings("custom", "llama3.1:8b", "ollama", mockServer.URL)
+	if err != nil {
+		t.Fatalf("SaveSettings failed: %v", err)
+	}
+
+	models, err := svc.ListModels()
+	if err != nil {
+		t.Fatalf("ListModels failed: %v", err)
+	}
+
+	if len(models) != 2 {
+		t.Errorf("Expected 2 models, got %d: %v", len(models), models)
+	}
+}


### PR DESCRIPTION
## Fix

Applied the proposed fix in `internal/core/ai/ai.go`.

### Root cause

`listOpenAIModels` applied a hard-coded prefix filter that silently dropped any model whose ID didn't start with `gpt-` or `o1-`. Since local models (e.g. `llama3.1:8b`, `qwen3-coder:latest`) don't use those prefixes, the function returned an empty list even though the HTTP request to the custom endpoint succeeded.

### Changes

**File:** `internal/core/ai/ai.go` — `listOpenAIModels` function

1. **Added `isCustomProvider` flag** — set to `true` when a non-empty `baseURL` is passed. This distinguishes calls to the official OpenAI API from calls to a custom/local endpoint.

2. **Bypassed the prefix filter for custom providers** — the filter condition now reads:
   ```go
   if isCustomProvider || strings.HasPrefix(m.ID, "gpt-") || strings.HasPrefix(m.ID, "o1-") {
   ```
   When using a custom endpoint, all models returned by the API are included as-is. The existing OpenAI prefix filter is unchanged for non-custom providers.

3. **Updated error label** — `formatAPIError("OpenAI", ...)` → `formatAPIError("OpenAI/Custom", ...)` so error messages accurately reflect which provider type is in use.

### Verification

Added a unit test `TestCustomProviderListModels_NonOpenAIModels` to `internal/core/ai/ai_test.go` that spins up a mock HTTP server returning Ollama-style model IDs (`llama3.1:8b`, `qwen3-coder:latest`) and asserts they are no longer silently dropped. All existing tests continue to pass.

```
go test ./internal/core/ai/...

ok      github.com/snehmatic/mindloop/internal/core/ai
```

<img width="949" height="833" alt="Screenshot 2026-05-18 143833" src="https://github.com/user-attachments/assets/970d1a01-8f1c-4bae-8488-032550f9176b" />